### PR TITLE
sqlite3_flutter_libsがEOLになったのでdrift_flutterで代替

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -221,6 +221,31 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - sqlite3 (3.52.0):
+    - sqlite3/common (= 3.52.0)
+  - sqlite3/common (3.52.0)
+  - sqlite3/dbstatvtab (3.52.0):
+    - sqlite3/common
+  - sqlite3/fts5 (3.52.0):
+    - sqlite3/common
+  - sqlite3/math (3.52.0):
+    - sqlite3/common
+  - sqlite3/perf-threadsafe (3.52.0):
+    - sqlite3/common
+  - sqlite3/rtree (3.52.0):
+    - sqlite3/common
+  - sqlite3/session (3.52.0):
+    - sqlite3/common
+  - sqlite3_flutter_libs (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - sqlite3 (~> 3.52.0)
+    - sqlite3/dbstatvtab
+    - sqlite3/fts5
+    - sqlite3/math
+    - sqlite3/perf-threadsafe
+    - sqlite3/rtree
+    - sqlite3/session
 
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
@@ -237,6 +262,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -269,6 +295,7 @@ SPEC REPOS:
     - PromisesObjC
     - PromisesSwift
     - RecaptchaInterop
+    - sqlite3
 
 EXTERNAL SOURCES:
   connectivity_plus:
@@ -299,6 +326,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sqlite3_flutter_libs:
+    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
 
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
@@ -344,6 +373,8 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
+  sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
 
 PODFILE CHECKSUM: c1da8b0fc9dbcc55c108afc61de4108057f1f208
 

--- a/lib/src/app/database/app_database.dart
+++ b/lib/src/app/database/app_database.dart
@@ -1,10 +1,6 @@
-import 'dart:io';
-
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
+import 'package:drift_flutter/drift_flutter.dart';
 import 'package:flutter_sample/src/features/memos/data/memo_table.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 
 part 'app_database.g.dart';
 
@@ -12,17 +8,9 @@ part 'app_database.g.dart';
 @DriftDatabase(tables: [Memos])
 class AppDatabase extends _$AppDatabase {
   /// コンストラクタ
-  AppDatabase([QueryExecutor? e]) : super(e ?? _openConnection());
+  AppDatabase([QueryExecutor? e])
+    : super(e ?? driftDatabase(name: 'my_app_db'));
 
   @override
   int get schemaVersion => 1;
-}
-
-/// スマホのどこにデータを保存するかを決める
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final dbFolder = await getApplicationDocumentsDirectory();
-    final file = File(p.join(dbFolder.path, 'db.sqlite'));
-    return NativeDatabase.createInBackground(file);
-  });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -345,6 +345,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.31.0"
+  drift_flutter:
+    dependency: "direct main"
+    description:
+      name: drift_flutter
+      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   envied:
     dependency: "direct main"
     description:
@@ -1395,13 +1403,13 @@ packages:
     source: hosted
     version: "2.9.4"
   sqlite3_flutter_libs:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0+eol"
+    version: "0.5.42"
   sqlparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   shared_preferences: ^2.5.3
   flutter_secure_storage: ^10.0.0
   drift: ^2.29.0
-  sqlite3_flutter_libs: ^0.6.0+eol
+  drift_flutter: ^0.2.8
 
   # --- 🧱 JSONシリアライズ・デシリアライズ ---
   freezed_annotation: ^3.1.0

--- a/test/src/app/database/app_database_test.dart
+++ b/test/src/app/database/app_database_test.dart
@@ -1,6 +1,5 @@
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_sample/src/app/database/app_database.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -62,31 +61,6 @@ void main() {
       await database.delete(database.memos).delete(memos.first);
       memos = await database.select(database.memos).get();
       expect(memos.isEmpty, true);
-    });
-
-    test('_openConnection は正しくLazyDatabaseを初期化する', () async {
-      // path_provider のモックを設定
-      const channel = MethodChannel('plugins.flutter.io/path_provider');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (methodCall) async {
-            if (methodCall.method == 'getApplicationDocumentsDirectory') {
-              return '.';
-            }
-            return null;
-          });
-
-      // デフォルトコンストラクタを呼び出す
-      final defaultDb = AppDatabase();
-
-      // LazyDatabaseのコールバックをトリガーするために一度クエリを実行する
-      // エラーがスローされても、LazyDatabaseの中身が実行されればカバレッジは通る
-      try {
-        await defaultDb.select(defaultDb.memos).get();
-      } on Object catch (_) {
-        // NativeDatabaseの初期化に関連するエラーなどはここでは無視する
-      }
-
-      await defaultDb.close();
     });
   });
 }


### PR DESCRIPTION
# SQLiteがAndroidでエラーになる件への対応

## 📝 概要

最新のsqlite3_flutter_libsがEOLになった関係でAndroidのSQLiteアクセスでエラーが発生していた。
元々、driftを使っていたこともあり代替としてdrift_flutterを使うことで対応した。

## ✅ 確認事項

- [x] AI（Gemini Code Assist）によるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューはPR作成時に自動で行われますが、ドラフトの場合は実行されないのでドラフトを解除したタイミングで手動実行（`/gemini review`） すること
  - レビュー後に大幅な変更を行った場合は手動で再度レビューを実行（`/gemini review`） すること

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)
- [ ] レビューアーに依頼する前にプルリクエストの要約（サマリー）をAIに作成（`/gemini summary`） してもらっているか

## ❕ 関連するIssue

Closes #79 
