### PR TITLE
refactor: 画面遷移をGoRouterのリダイレクトによる自動制御に一元化し、個別画面での遷移処理を削除

### DIFF
--- a/docs/firebase_authentication.md
+++ b/docs/firebase_authentication.md
@@ -70,37 +70,28 @@ final authRepo = ref.read(firebaseAuthRepositoryProvider);
 await authRepo.signUp(emailCtrl.text, passwordCtrl.text);
 await authRepo.sendEmailVerification();
 
-// メール認証待ち画面へ遷移
-if (context.mounted) {
-    const FirebaseEmailVerificationRoute().go(context);
-}
+// 💡 登録が成功すると、認証状態の変更をルーター（GoRouter）が検知し、
+// 💡 認証ガード（firebaseAuthGuard）の働きによって自動的にメール認証画面へリダイレクトされます。
 ```
 
-### 2. メールアプリから戻った際の自動チェック（Hooksの活用）
+### 2. メールアプリから戻った際の自動チェック（ライフサイクルの監視）
 
-ユーザーが「メールアプリを開いてリンクを踏み、再びこのアプリに戻ってくる」という行動を前提とし、`flutter_hooks` の `useAppLifecycleState` を使って **フォアグラウンド復帰時（resumed）** に自動でリロードをかけます。
+ユーザーが「メールアプリを開いてリンクを踏み、再びこのアプリに戻ってくる」という行動を前提とし、アプリのライフサイクルを監視して **フォアグラウンド復帰時（resumed）** に自動でユーザー情報をリロードします。
 
 ```dart
 // lib/src/features/auth/presentation/firebase_email_verification_screen.dart
 
-// 💡 1. ライフサイクルを監視
-final lifecycleState = useAppLifecycleState();
-
-useEffect(() {
-  // アプリに復帰した瞬間に、Firebaseのユーザー状態をリロード
-  if (lifecycleState == AppLifecycleState.resumed) {
-    unawaited(ref.read(firebaseAuthRepositoryProvider).reloadCurrentUser());
-  }
-  return null;
-}, [lifecycleState]);
-
-// 💡 2. 状態の変更を検知して自動遷移
-ref.listen(firebaseAuthStateProvider, (previous, next) {
-  if (next != null && next.emailVerified) {
-    // 認証完了！ホーム画面へ
-    const HomeRoute().go(context);
+// 💡 1. ライフサイクルを監視して、フォアグラウンド復帰時にリロードを実行
+ref.listen(appLifecycleProvider, (previous, next) {
+  if (next == AppLifecycleState.resumed) {
+    unawaited(
+      ref.read(firebaseAuthRepositoryProvider).reloadCurrentUser(),
+    );
   }
 });
+
+// 💡 2. 状態の変更（メール認証の完了）はルーター（app_router.dart / firebaseAuthGuard）が自動検知し、
+// 💡    自動でホーム画面（HomeRoute）へリダイレクトするため、画面側での監視・遷移処理は不要です。
 ```
 
 この実装により、無駄な通信を一切行わず、ユーザーがアプリに戻ってきた瞬間にスッと次の画面へ進む最高クラスのUXを提供しています。

--- a/lib/src/app/router/firebase_auth_guard.dart
+++ b/lib/src/app/router/firebase_auth_guard.dart
@@ -23,6 +23,11 @@ String? firebaseAuthGuard(Ref ref, GoRouterState state) {
     return emailVerificationPath;
   }
 
+  // メール認証が完了した状態でメール認証画面にアクセスした場合は、ホーム画面へリダイレクトする
+  if (isLoggedIn && isEmailVerified && goingToEmailVerification) {
+    return const HomeRoute().location;
+  }
+
   return AuthGuardHelper(
     loginLocation: const LoginRoute().location,
     defaultLocation: const HomeRoute().location,

--- a/lib/src/features/auth/presentation/firebase_email_verification_screen.dart
+++ b/lib/src/features/auth/presentation/firebase_email_verification_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_sample/src/core/ui/error_handler.dart';
@@ -22,21 +20,15 @@ class FirebaseEmailVerificationScreen extends HookConsumerWidget {
     final isReloading = useState(false);
     final isResending = useState(false);
 
-    ref.listen(appLifecycleProvider, (previous, next) {
+    ref.listen(appLifecycleProvider, (previous, next) async {
       if (next == AppLifecycleState.resumed) {
-        unawaited(
-          () async {
-            try {
-              await ref
-                  .read(firebaseAuthRepositoryProvider)
-                  .reloadCurrentUser();
-            } on Exception catch (e) {
-              if (context.mounted) {
-                ErrorHandler.showSnackBar(context, e);
-              }
-            }
-          }(),
-        );
+        try {
+          await ref.read(firebaseAuthRepositoryProvider).reloadCurrentUser();
+        } on Exception catch (e) {
+          if (context.mounted) {
+            ErrorHandler.showSnackBar(context, e);
+          }
+        }
       }
     });
 

--- a/lib/src/features/auth/presentation/firebase_email_verification_screen.dart
+++ b/lib/src/features/auth/presentation/firebase_email_verification_screen.dart
@@ -2,12 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/core/ui/error_handler.dart';
 import 'package:flutter_sample/src/core/ui/l10n_extension.dart';
 import 'package:flutter_sample/src/core/ui/snackbar_extension.dart';
 import 'package:flutter_sample/src/core/utils/app_lifecycle_provider.dart';
-import 'package:flutter_sample/src/features/auth/application/firebase_auth_state_notifier.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -24,29 +22,23 @@ class FirebaseEmailVerificationScreen extends HookConsumerWidget {
     final isReloading = useState(false);
     final isResending = useState(false);
 
-    ref
-      ..listen(appLifecycleProvider, (previous, next) {
-        if (next == AppLifecycleState.resumed) {
-          unawaited(
-            () async {
-              try {
-                await ref
-                    .read(firebaseAuthRepositoryProvider)
-                    .reloadCurrentUser();
-              } on Exception catch (e) {
-                if (context.mounted) {
-                  ErrorHandler.showSnackBar(context, e);
-                }
+    ref.listen(appLifecycleProvider, (previous, next) {
+      if (next == AppLifecycleState.resumed) {
+        unawaited(
+          () async {
+            try {
+              await ref
+                  .read(firebaseAuthRepositoryProvider)
+                  .reloadCurrentUser();
+            } on Exception catch (e) {
+              if (context.mounted) {
+                ErrorHandler.showSnackBar(context, e);
               }
-            }(),
-          );
-        }
-      })
-      ..listen(firebaseAuthStateProvider, (previous, next) {
-        if (next != null && next.emailVerified) {
-          const HomeRoute().go(context);
-        }
-      });
+            }
+          }(),
+        );
+      }
+    });
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.emailVerificationTitle)),

--- a/lib/src/features/auth/presentation/firebase_sign_up_screen.dart
+++ b/lib/src/features/auth/presentation/firebase_sign_up_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/core/ui/error_handler.dart';
 import 'package:flutter_sample/src/core/ui/l10n_extension.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
@@ -76,10 +75,6 @@ class FirebaseSignUpScreen extends HookConsumerWidget {
                         await ref
                             .read(firebaseAuthRepositoryProvider)
                             .sendEmailVerification();
-
-                        if (context.mounted) {
-                          const EmailVerificationRoute().go(context);
-                        }
                       } on Exception catch (e) {
                         if (context.mounted) {
                           ErrorHandler.showSnackBar(context, e);

--- a/lib/src/features/settings/presentation/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/core/config/app_config_provider.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_sample/src/core/config/locale_provider.dart';
@@ -189,10 +188,6 @@ class _LogoutButton extends ConsumerWidget {
   Future<void> _handleLogout(BuildContext context, WidgetRef ref) async {
     try {
       await ref.read(firebaseAuthRepositoryProvider).signOut();
-
-      if (context.mounted) {
-        const LoginRoute().go(context);
-      }
     } on Exception catch (e) {
       if (context.mounted) {
         ErrorHandler.showSnackBar(context, e);

--- a/test/src/app/router/app_router_test.dart
+++ b/test/src/app/router/app_router_test.dart
@@ -231,6 +231,81 @@ void main() {
       expect(tester.takeException(), isNull);
       await teardownWidget(tester, container);
     });
+
+    testWidgets(
+      'ログイン中かつメール未認証の時、FirebaseEmailVerificationScreen にリダイレクトされること',
+      (
+        tester,
+      ) async {
+        when(() => mockUser.emailVerified).thenReturn(false);
+
+        final container = createContainer(isLoggedIn: true, useFirebase: true);
+
+        await tester.pumpWidget(createTestWidget(container));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(find.byType(FirebaseEmailVerificationScreen), findsOneWidget);
+        await teardownWidget(tester, container);
+      },
+    );
+
+    testWidgets('メール未認証画面からメール認証完了になった時、自動で HomeScreen に遷移すること', (
+      tester,
+    ) async {
+      when(() => mockUser.emailVerified).thenReturn(false);
+
+      final container = createContainer(isLoggedIn: true, useFirebase: true);
+
+      await tester.pumpWidget(createTestWidget(container));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.byType(FirebaseEmailVerificationScreen), findsOneWidget);
+
+      final verifiedUser = MockUser();
+      when(() => verifiedUser.uid).thenReturn('dummy_uid_123');
+      when(() => verifiedUser.emailVerified).thenReturn(true);
+      when(() => verifiedUser.isAnonymous).thenReturn(false);
+      when(() => verifiedUser.email).thenReturn('test@example.com');
+      when(() => verifiedUser.displayName).thenReturn('Test User');
+      when(() => verifiedUser.phoneNumber).thenReturn(null);
+      when(() => verifiedUser.photoURL).thenReturn(null);
+      when(() => verifiedUser.tenantId).thenReturn(null);
+      when(() => verifiedUser.refreshToken).thenReturn('dummy_token');
+
+      (container.read(firebaseAuthStateProvider.notifier)
+              as _FakeFirebaseAuthStateNotifier)
+          .changeState(verifiedUser);
+
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.byType(HomeScreen), findsOneWidget);
+      await teardownWidget(tester, container);
+    });
+
+    testWidgets('ログイン状態からログアウトした時、自動で FirebaseLoginScreen に戻ること', (
+      tester,
+    ) async {
+      final container = createContainer(isLoggedIn: true, useFirebase: true);
+
+      await tester.pumpWidget(createTestWidget(container));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.byType(HomeScreen), findsOneWidget);
+
+      (container.read(firebaseAuthStateProvider.notifier)
+              as _FakeFirebaseAuthStateNotifier)
+          .changeState(null);
+
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.byType(FirebaseLoginScreen), findsOneWidget);
+      await teardownWidget(tester, container);
+    });
   });
 
   group('RouteData ユニットテスト', () {

--- a/test/src/features/auth/presentation/firebase_email_verification_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_email_verification_screen_test.dart
@@ -38,10 +38,6 @@ class FakeFirebaseAuthStateNotifier extends FirebaseAuthStateNotifier {
 
   @override
   User? build() => initialState;
-
-  void updateState(User? newUser) {
-    state = newUser;
-  }
 }
 
 class FakeAppLifecycle extends AppLifecycle {
@@ -277,37 +273,6 @@ void main() {
 
         verify(() => mockAuthRepo.reloadCurrentUser()).called(1);
         expect(find.byType(SnackBar), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'ユーザー状態が変更され emailVerified == true になると、自動で HomeRoute に遷移すること',
-      (tester) async {
-        when(() => mockUser.emailVerified).thenReturn(false);
-
-        final container = ProviderContainer(
-          overrides: [
-            firebaseAuthRepositoryProvider.overrideWithValue(mockAuthRepo),
-            firebaseAuthStateProvider.overrideWith(
-              () => FakeFirebaseAuthStateNotifier(mockUser),
-            ),
-          ],
-        );
-
-        await tester.pumpWidget(createTestWidget(container));
-        await tester.pumpAndSettle();
-
-        final verifiedUser = MockUser();
-        when(() => verifiedUser.emailVerified).thenReturn(true);
-
-        (container.read(firebaseAuthStateProvider.notifier)
-                as FakeFirebaseAuthStateNotifier)
-            .updateState(verifiedUser);
-
-        await tester.pumpAndSettle();
-
-        expect(find.textContaining('Navigated to'), findsOneWidget);
-        expect(find.text('メール認証'), findsNothing);
       },
     );
 

--- a/test/src/features/auth/presentation/firebase_sign_up_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_sign_up_screen_test.dart
@@ -102,7 +102,7 @@ void main() {
       verifyNever(() => mockAuthRepo.sendEmailVerification());
     });
 
-    testWidgets('入力値が Repository に渡され、成功時に確認メールを送信して画面遷移すること', (tester) async {
+    testWidgets('入力値が Repository に渡され、成功時に確認メールを送信すること', (tester) async {
       when(
         () => mockAuthRepo.signUp('test@example.com', 'password123'),
       ).thenAnswer((_) async {});
@@ -129,9 +129,6 @@ void main() {
         () => mockAuthRepo.signUp('test@example.com', 'password123'),
       ).called(1);
       verify(() => mockAuthRepo.sendEmailVerification()).called(1);
-
-      // 画面遷移したことを確認
-      expect(find.textContaining('Navigated to'), findsOneWidget);
     });
 
     testWidgets('サインアップ処理中、ローディング表示になり入力がロックされること', (tester) async {

--- a/test/src/features/settings/presentation/settings_screen_test.dart
+++ b/test/src/features/settings/presentation/settings_screen_test.dart
@@ -250,7 +250,7 @@ void main() {
           expect(find.byKey(const Key('logout_button')), findsNothing);
         });
 
-        testWidgets('useAuth == true でログアウト成功時、LoginRouteに遷移すること', (
+        testWidgets('useAuth == true でログアウト成功時、signOut処理が呼ばれること', (
           tester,
         ) async {
           // ビューポートサイズを固定
@@ -275,7 +275,6 @@ void main() {
           await tester.pumpAndSettle();
 
           verify(() => mockAuthRepo.signOut()).called(1);
-          expect(find.textContaining('Navigated to'), findsOneWidget);
         });
 
         testWidgets('ログアウト時に例外が発生した場合、SnackBarでエラーが表示されること', (tester) async {


### PR DESCRIPTION
## 📝 概要

- firebaseAuthGuardにメール認証完了時のホーム画面への自動リダイレクトを追加
- SignUp、EmailVerification、Settings画面から手動の画面遷移（go）コードを削除
- app_router_testに自動リダイレクトの動作検証用テストを追加し、各画面のテストを修正
- firebase_authentication.mdの解説とサンプルコードを最新の実装に合わせて更新

## ✅ 確認事項

- [x] AI（Gemini Code Assist）によるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューはPR作成時に自動で行われますが、ドラフトの場合は実行されないのでドラフトを解除したタイミングで手動実行（`/gemini review`） すること
  - レビュー後に大幅な変更を行った場合は手動で再度レビューを実行（`/gemini review`） すること

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)
- [x] レビューアーに依頼する前にプルリクエストの要約（サマリー）をAIに作成（`/gemini summary`） してもらっているか

## ❕ 関連するIssue

Closes #122 
