### PR TITLE
feat: アニメーション付きスプラッシュ画面の追加と遷移制御の実装

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -104,16 +104,25 @@ lib/src/app/router/
 
 ---
 
-### 🧪 動作フロー
+### 🧪 動作フローとスプラッシュ画面表示時間保証
+
+スプラッシュ画面のチラつきを防ぎ、かつリッチなアニメーション（最低2秒）をユーザーに確実に見せるため、以下のフローで制御を行っています。
 
 ```plaintext
-アプリ起動
+アプリ起動（初期ルートは /splash）
    ↓
-SplashScreen表示（認証状態チェック）
+SplashScreen表示 ＆ アニメーション開始（最低2秒間表示）
    ↓
-【認証済み】 → HomeRoute("/")へ
-【未認証】   → LoginRoute("/login")へ
+2秒経過後にスプラッシュ完了（splashStateProvider = true に更新）
+   ↓
+GoRouter のリダイレクト処理（authGuard / firebaseAuthGuard）が再評価
+   ↓
+現在地が /splash かつスプラッシュ完了済みの場合：
+   ├─【認証済み】 ──→ HomeRoute("/") へ自動遷移
+   └─【未認証】   ──→ LoginRoute("/login") へ自動遷移
 ```
+
+この制御を行うため、`app_router.dart` 内で `splashStateProvider` をリッスンし、状態が完了（`true`）に変わったタイミングでルーターの更新（リダイレクト処理の再判定をトリガー）を行っています。
 
 ---
 

--- a/lib/src/app/router/app_router.dart
+++ b/lib/src/app/router/app_router.dart
@@ -24,6 +24,7 @@ import 'package:flutter_sample/src/features/home/presentation/home_screen.dart';
 import 'package:flutter_sample/src/features/memos/presentation/memo_screen.dart';
 import 'package:flutter_sample/src/features/settings/presentation/settings_screen.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_screen.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:flutter_sample/src/features/user/presentation/user_list_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -41,6 +42,12 @@ GoRouter router(Ref ref) {
 
   // 認証状態の変更を検知して GoRouter にルーティングの再評価を促すための Listenable
   final routerListenable = ValueNotifier<bool>(false);
+
+  // スプラッシュ画面の表示が完了したときも、画面遷移を再評価する
+  ref.listen(
+    splashStateProvider,
+    (_, _) => routerListenable.value = !routerListenable.value,
+  );
 
   // 使用している認証方式のみを監視対象にする
   if (useFirebase) {

--- a/lib/src/app/router/app_router.g.dart
+++ b/lib/src/app/router/app_router.g.dart
@@ -354,4 +354,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'1411504caadfd9fade779030d77cdb69d70f7ba7';
+String _$routerHash() => r'369cf323d147be50ba68940422698bc551f37f62';

--- a/lib/src/app/router/auth_guard.dart
+++ b/lib/src/app/router/auth_guard.dart
@@ -1,11 +1,18 @@
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/base_auth_guard.dart';
 import 'package:flutter_sample/src/features/auth/application/auth_state_notifier.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// 認証状態に応じてリダイレクト先を判定するガード（認証トークン版）
 String? authGuard(Ref ref, GoRouterState state) {
+  // スプラッシュ画面の表示が完了していない場合は、強制的にスプラッシュ画面にとどまる
+  final isSplashFinished = ref.read(splashStateProvider);
+  if (!isSplashFinished) {
+    return const SplashRoute().location;
+  }
+
   // 現在のログイン状態を取得（コールバック内のため watch ではなく read を使用）
   final authState = ref.read(authStateProvider);
 
@@ -17,6 +24,14 @@ String? authGuard(Ref ref, GoRouterState state) {
 
   // ユーザーがログイン済みかどうか
   final isLoggedIn = authState.value ?? false;
+
+  // スプラッシュ表示が完了しており、かつ現在スプラッシュ画面にいる場合は、
+  // ログイン状態に応じた適切な画面（ホームまたはログイン）へリダイレクトする
+  if (state.uri.path == const SplashRoute().location) {
+    return isLoggedIn
+        ? const HomeRoute().location
+        : const LoginRoute().location;
+  }
 
   return AuthGuardHelper(
     loginLocation: const LoginRoute().location,

--- a/lib/src/app/router/firebase_auth_guard.dart
+++ b/lib/src/app/router/firebase_auth_guard.dart
@@ -1,16 +1,31 @@
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/base_auth_guard.dart';
 import 'package:flutter_sample/src/features/auth/application/firebase_auth_state_notifier.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// 認証状態に応じてリダイレクト先を判定するガード（Firebase Authentication版）
 String? firebaseAuthGuard(Ref ref, GoRouterState state) {
+  // スプラッシュ画面の表示が完了していない場合は、強制的にスプラッシュ画面にとどまる
+  final isSplashFinished = ref.read(splashStateProvider);
+  if (!isSplashFinished) {
+    return const SplashRoute().location;
+  }
+
   // 現在のログイン状態を取得（コールバック内のため watch ではなく read を使用）
   final authState = ref.read(firebaseAuthStateProvider);
 
   // ユーザーがログイン済みかどうか
   final isLoggedIn = authState != null;
+
+  // スプラッシュ表示が完了しており、かつ現在スプラッシュ画面にいる場合は、
+  // ログイン状態に応じた適切な画面（ホームまたはログイン）へリダイレクトする
+  if (state.uri.path == const SplashRoute().location) {
+    return isLoggedIn
+        ? const HomeRoute().location
+        : const LoginRoute().location;
+  }
 
   // メール未認証の場合は、常にメール認証待ち画面へ誘導する
   final isEmailVerified = authState?.emailVerified ?? false;

--- a/lib/src/features/splash/presentation/splash_screen.dart
+++ b/lib/src/features/splash/presentation/splash_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_sample/src/core/ui/l10n_extension.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -120,20 +121,20 @@ class SplashLogo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Column(
+    return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         // ロゴのアイコン
-        Icon(
+        const Icon(
           Icons.flutter_dash,
           size: SplashConfig.logoSize,
           color: SplashConfig.logoColor,
         ),
-        SizedBox(height: 16),
+        const SizedBox(height: 16),
         // アプリタイトル
         Text(
-          'Flutter Sample App',
-          style: TextStyle(
+          context.l10n.appTitle,
+          style: const TextStyle(
             color: SplashConfig.logoColor,
             fontSize: 24,
             fontWeight: FontWeight.bold,

--- a/lib/src/features/splash/presentation/splash_screen.dart
+++ b/lib/src/features/splash/presentation/splash_screen.dart
@@ -1,14 +1,146 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
 
-/// スプラッシュ画面
-class SplashScreen extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 🎨 スプラッシュ画面のデザインカスタマイズ用定数
+class SplashConfig {
+  /// スプラッシュ表示時間（最小2秒）
+  static const Duration displayDuration = Duration(seconds: 2);
+
+  /// アニメーションの動作時間
+  static const Duration animationDuration = Duration(milliseconds: 1500);
+
+  /// 背景のグラデーション開始色（プライマリに近い色）
+  static const Color gradientStartColor = Color(0xFF1E3C72);
+
+  /// 背景のグラデーション終了色
+  static const Color gradientEndColor = Color(0xFF2A5298);
+
+  /// ロゴの色
+  static const Color logoColor = Colors.white;
+
+  /// ロゴのサイズ
+  static const double logoSize = 100;
+}
+
+/// 🌊 スプラッシュ画面
+///
+/// 起動時に表示され、心地よいフェードイン＆バウンドアニメーションを行った後、
+/// 最低表示時間である2秒を満たした時点で次の画面へ遷移します。
+class SplashScreen extends HookConsumerWidget {
   /// コンストラクタ
   const SplashScreen({super.key});
 
   @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 1. アニメーションコントローラーの作成（flutter_hooks を使用）
+    final animationController = useAnimationController(
+      duration: SplashConfig.animationDuration,
+    );
+
+    // 2. フェードイン（不透明度）のアニメーションを定義
+    final opacityAnimation = useMemoized(
+      () => Tween<double>(begin: 0, end: 1).animate(
+        CurvedAnimation(
+          parent: animationController,
+          curve: const Interval(0, 0.6, curve: Curves.easeIn),
+        ),
+      ),
+      [animationController],
+    );
+
+    // 3. バウンド（ふわっと少し上に浮き上がる）のアニメーションを定義
+    final slideAnimation = useMemoized(
+      () => Tween<double>(begin: 30, end: 0).animate(
+        CurvedAnimation(
+          parent: animationController,
+          curve: const Interval(0.2, 1, curve: Curves.easeOutBack),
+        ),
+      ),
+      [animationController],
+    );
+
+    // 4. 初回描画時にアニメーション開始とタイマーを起動
+    useEffect(
+      () {
+        // アニメーションを開始
+        unawaited(animationController.forward());
+
+        // 最低2秒待ってから、スプラッシュ終了フラグを立てる
+        final timer = Timer(SplashConfig.displayDuration, () {
+          ref.read(splashStateProvider.notifier).finishSplash();
+        });
+
+        // クリーンアップ処理（アンマウント時にタイマーをキャンセル）
+        return timer.cancel;
+      },
+      const [],
+    );
+
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              SplashConfig.gradientStartColor,
+              SplashConfig.gradientEndColor,
+            ],
+          ),
+        ),
+        child: Center(
+          child: AnimatedBuilder(
+            animation: animationController,
+            builder: (context, child) {
+              return Transform.translate(
+                offset: Offset(0, slideAnimation.value),
+                child: Opacity(
+                  opacity: opacityAnimation.value,
+                  child: const SplashLogo(),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 🎨 スプラッシュ画面の中央に表示されるロゴWidget
+///
+/// デザインを変更したい場合は、このWidget内の実装を書き換えます。
+class SplashLogo extends StatelessWidget {
+  /// コンストラクタ
+  const SplashLogo({super.key});
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: CircularProgressIndicator()),
+    return const Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // ロゴのアイコン
+        Icon(
+          Icons.flutter_dash,
+          size: SplashConfig.logoSize,
+          color: SplashConfig.logoColor,
+        ),
+        SizedBox(height: 16),
+        // アプリタイトル
+        Text(
+          'Flutter Sample App',
+          style: TextStyle(
+            color: SplashConfig.logoColor,
+            fontSize: 24,
+            fontWeight: FontWeight.bold,
+            letterSpacing: 1.5,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/features/splash/presentation/splash_state_provider.dart
+++ b/lib/src/features/splash/presentation/splash_state_provider.dart
@@ -1,0 +1,20 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'splash_state_provider.g.dart';
+
+/// 🌊 スプラッシュ画面の表示完了状態を管理するNotifierプロバイダー
+///
+/// アプリ起動時に最低表示時間（例：2秒）を満たしたかどうかを管理します。
+@Riverpod(keepAlive: true)
+class SplashState extends _$SplashState {
+  @override
+  bool build() {
+    // 初期状態は「スプラッシュ画面表示中 (false)」
+    return false;
+  }
+
+  /// スプラッシュ表示が完了したことを通知し、状態を true (完了) に更新します。
+  void finishSplash() {
+    state = true;
+  }
+}

--- a/lib/src/features/splash/presentation/splash_state_provider.g.dart
+++ b/lib/src/features/splash/presentation/splash_state_provider.g.dart
@@ -1,0 +1,74 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'splash_state_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 🌊 スプラッシュ画面の表示完了状態を管理するNotifierプロバイダー
+///
+/// アプリ起動時に最低表示時間（例：2秒）を満たしたかどうかを管理します。
+
+@ProviderFor(SplashState)
+final splashStateProvider = SplashStateProvider._();
+
+/// 🌊 スプラッシュ画面の表示完了状態を管理するNotifierプロバイダー
+///
+/// アプリ起動時に最低表示時間（例：2秒）を満たしたかどうかを管理します。
+final class SplashStateProvider extends $NotifierProvider<SplashState, bool> {
+  /// 🌊 スプラッシュ画面の表示完了状態を管理するNotifierプロバイダー
+  ///
+  /// アプリ起動時に最低表示時間（例：2秒）を満たしたかどうかを管理します。
+  SplashStateProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'splashStateProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$splashStateHash();
+
+  @$internal
+  @override
+  SplashState create() => SplashState();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$splashStateHash() => r'365421d366397fc98d5ed8143e297cbcd5e20202';
+
+/// 🌊 スプラッシュ画面の表示完了状態を管理するNotifierプロバイダー
+///
+/// アプリ起動時に最低表示時間（例：2秒）を満たしたかどうかを管理します。
+
+abstract class _$SplashState extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/src/app/router/app_router_test.dart
+++ b/test/src/app/router/app_router_test.dart
@@ -148,7 +148,15 @@ void main() {
     return container;
   }
 
-  Widget createTestWidget(ProviderContainer container) {
+  Widget createTestWidget(WidgetTester tester, ProviderContainer container) {
+    // 画面サイズを固定し、テスト終了時にリセットする
+    tester.view.physicalSize = const Size(1080, 1920);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
     return UncontrolledProviderScope(
       container: container,
       child: MaterialApp.router(
@@ -173,7 +181,7 @@ void main() {
     testWidgets('ログイン済みの時、HomeScreen が表示されること', (tester) async {
       final container = createContainer(isLoggedIn: true, useFirebase: true);
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
@@ -186,7 +194,7 @@ void main() {
     ) async {
       final container = createContainer(isLoggedIn: false, useFirebase: false);
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
@@ -199,7 +207,7 @@ void main() {
     ) async {
       final container = createContainer(isLoggedIn: false, useFirebase: true);
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
@@ -210,7 +218,7 @@ void main() {
     testWidgets('存在しないパスにアクセスした時、NotFoundScreenが表示されること', (tester) async {
       final container = createContainer(isLoggedIn: true, useFirebase: false);
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -227,7 +235,7 @@ void main() {
     testWidgets('認証状態の変更を検知してルーターが更新（Listen）されること', (tester) async {
       final container = createContainer(isLoggedIn: false, useFirebase: true);
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pumpAndSettle();
 
       // 最初は未ログインなので FirebaseLoginScreen が表示されていること
@@ -254,7 +262,7 @@ void main() {
         isSplashFinished: false,
       );
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pump();
 
       // 最初はスプラッシュ未完了なので SplashScreen が表示されていること
@@ -279,7 +287,7 @@ void main() {
 
         final container = createContainer(isLoggedIn: true, useFirebase: true);
 
-        await tester.pumpWidget(createTestWidget(container));
+        await tester.pumpWidget(createTestWidget(tester, container));
         await tester.pump();
         await tester.pump(const Duration(seconds: 1));
 
@@ -295,7 +303,7 @@ void main() {
 
       final container = createContainer(isLoggedIn: true, useFirebase: true);
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
@@ -328,7 +336,7 @@ void main() {
     ) async {
       final container = createContainer(isLoggedIn: true, useFirebase: true);
 
-      await tester.pumpWidget(createTestWidget(container));
+      await tester.pumpWidget(createTestWidget(tester, container));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
@@ -350,6 +358,14 @@ void main() {
     testWidgets('LoginRoute.build: 直接 build メソッドを呼んだ時に正しいWidgetを返すこと', (
       tester,
     ) async {
+      // 画面サイズを固定し、テスト終了時にリセットする
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
       final container = ProviderContainer(
         overrides: [
           envConfigProvider.overrideWithValue(

--- a/test/src/app/router/app_router_test.dart
+++ b/test/src/app/router/app_router_test.dart
@@ -24,6 +24,7 @@ import 'package:flutter_sample/src/features/home/presentation/home_screen.dart';
 import 'package:flutter_sample/src/features/memos/presentation/memo_screen.dart';
 import 'package:flutter_sample/src/features/settings/presentation/settings_screen.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_screen.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:flutter_sample/src/features/user/presentation/user_list_screen.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -40,6 +41,15 @@ class MockGoRouterState extends Mock implements GoRouterState {}
 class MockBuildContext extends Mock implements BuildContext {}
 
 class MockUser extends Mock implements User {}
+
+// --- SplashStateのフェイク定義 ---
+class FakeSplashState extends SplashState {
+  FakeSplashState({required this.initialValue});
+  final bool initialValue;
+
+  @override
+  bool build() => initialValue;
+}
 
 class _FakeAuthStateNotifier extends AuthStateNotifier {
   _FakeAuthStateNotifier({required this.isLoggedIn});
@@ -104,6 +114,7 @@ void main() {
   ProviderContainer createContainer({
     required bool isLoggedIn,
     required bool useFirebase,
+    bool isSplashFinished = true,
   }) {
     final container = ProviderContainer(
       overrides: [
@@ -128,6 +139,9 @@ void main() {
             isLoggedIn: isLoggedIn,
             mockUser: mockUser,
           ),
+        ),
+        splashStateProvider.overrideWith(
+          () => FakeSplashState(initialValue: isSplashFinished),
         ),
       ],
     )..listen(routerProvider, (_, _) {});
@@ -216,19 +230,43 @@ void main() {
       await tester.pumpWidget(createTestWidget(container));
       await tester.pumpAndSettle();
 
-      // authStateProvider の状態を強制的に変更する
-      (container.read(authStateProvider.notifier) as _FakeAuthStateNotifier)
-          .changeState(value: true);
-      await tester.pump();
+      // 最初は未ログインなので FirebaseLoginScreen が表示されていること
+      expect(find.byType(FirebaseLoginScreen), findsOneWidget);
 
       // firebaseAuthStateProvider の状態を強制的に変更する
       (container.read(firebaseAuthStateProvider.notifier)
               as _FakeFirebaseAuthStateNotifier)
           .changeState(mockUser);
+
+      // 遷移が完了するまで待つ
+      await tester.pumpAndSettle();
+
+      // ログイン状態になったので HomeScreen に遷移することを確認
+      expect(find.byType(HomeScreen), findsOneWidget);
+
+      await teardownWidget(tester, container);
+    });
+
+    testWidgets('スプラッシュ画面完了時にルーターが再評価されること', (tester) async {
+      final container = createContainer(
+        isLoggedIn: true,
+        useFirebase: false,
+        isSplashFinished: false,
+      );
+
+      await tester.pumpWidget(createTestWidget(container));
       await tester.pump();
 
-      // エラーが起きず正常に動作していればOK
-      expect(tester.takeException(), isNull);
+      // 最初はスプラッシュ未完了なので SplashScreen が表示されていること
+      expect(find.byType(SplashScreen), findsOneWidget);
+
+      // スプラッシュ完了状態にする
+      container.read(splashStateProvider.notifier).finishSplash();
+      await tester.pumpAndSettle();
+
+      // スプラッシュが完了したので HomeScreen に遷移すること
+      expect(find.byType(HomeScreen), findsOneWidget);
+
       await teardownWidget(tester, container);
     });
 

--- a/test/src/app/router/auth_guard_test.dart
+++ b/test/src/app/router/auth_guard_test.dart
@@ -4,12 +4,22 @@ import 'package:flutter/foundation.dart'; // SynchronousFuture 用
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/auth_guard.dart';
 import 'package:flutter_sample/src/features/auth/application/auth_state_notifier.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockGoRouterState extends Mock implements GoRouterState {}
+
+// --- SplashStateのフェイク定義 ---
+class FakeSplashState extends SplashState {
+  FakeSplashState({required this.initialValue});
+  final bool initialValue;
+
+  @override
+  bool build() => initialValue;
+}
 
 // --- Notifierのモック定義 ---
 class _FakeAuthStateNotifier extends AuthStateNotifier {
@@ -42,7 +52,11 @@ void main() {
     when(() => mockState.uri).thenReturn(Uri.parse('/'));
   });
 
-  String? executeGuard(AsyncValue<bool> authState, {String location = '/'}) {
+  String? executeGuard(
+    AsyncValue<bool> authState, {
+    String location = '/',
+    bool isSplashFinished = true,
+  }) {
     when(() => mockState.matchedLocation).thenReturn(location);
     when(() => mockState.uri).thenReturn(Uri.parse(location));
 
@@ -51,6 +65,9 @@ void main() {
         // 💡 修正ポイント: 引数なしの overrideWith
         authStateProvider.overrideWith(
           () => _FakeAuthStateNotifier(authState),
+        ),
+        splashStateProvider.overrideWith(
+          () => FakeSplashState(initialValue: isSplashFinished),
         ),
       ],
     );
@@ -106,6 +123,30 @@ void main() {
       );
       expect(result, startsWith(const LoginRoute().location));
       expect(result, contains('from=${Uri.encodeComponent('/')}'));
+    });
+
+    test('スプラッシュ未完了の場合、常に SplashRoute にリダイレクトすること', () {
+      final result = executeGuard(
+        const AsyncData<bool>(true),
+        isSplashFinished: false,
+      );
+      expect(result, const SplashRoute().location);
+    });
+
+    test('スプラッシュ完了後、スプラッシュ画面にいて未ログインの場合、ログイン画面へリダイレクトすること', () {
+      final result = executeGuard(
+        const AsyncData<bool>(false),
+        location: const SplashRoute().location,
+      );
+      expect(result, const LoginRoute().location);
+    });
+
+    test('スプラッシュ完了後、スプラッシュ画面にいてログイン済みの場合、ホーム画面へリダイレクトすること', () {
+      final result = executeGuard(
+        const AsyncData<bool>(true),
+        location: const SplashRoute().location,
+      );
+      expect(result, const HomeRoute().location);
     });
   });
 }

--- a/test/src/app/router/firebase_auth_guard_test.dart
+++ b/test/src/app/router/firebase_auth_guard_test.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/firebase_auth_guard.dart';
 import 'package:flutter_sample/src/features/auth/application/firebase_auth_state_notifier.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -11,6 +12,15 @@ class MockGoRouterState extends Mock implements GoRouterState {}
 
 class MockUser extends Mock implements User {}
 
+// --- SplashStateのフェイク定義 ---
+class FakeSplashState extends SplashState {
+  FakeSplashState({required this.initialValue});
+  final bool initialValue;
+
+  @override
+  bool build() => initialValue;
+}
+
 void main() {
   late MockGoRouterState mockState;
 
@@ -19,13 +29,20 @@ void main() {
     when(() => mockState.uri).thenReturn(Uri.parse('/'));
   });
 
-  String? executeGuard(User? user, {String location = '/'}) {
+  String? executeGuard(
+    User? user, {
+    String location = '/',
+    bool isSplashFinished = true,
+  }) {
     when(() => mockState.uri).thenReturn(Uri.parse(location));
 
     final container = ProviderContainer(
       overrides: [
         // firebaseAuthStateProvider を指定した User オブジェクトで上書き
         firebaseAuthStateProvider.overrideWithValue(user),
+        splashStateProvider.overrideWith(
+          () => FakeSplashState(initialValue: isSplashFinished),
+        ),
       ],
     );
     addTearDown(container.dispose);
@@ -77,6 +94,32 @@ void main() {
       // AuthGuardHelper によりログイン画面へリダイレクトされることを確認（fromパラメータ付き）
       expect(result, startsWith(const LoginRoute().location));
       expect(result, contains('from=${Uri.encodeComponent('/')}'));
+    });
+
+    test('スプラッシュ未完了の場合、常に SplashRoute にリダイレクトすること', () {
+      final mockUser = MockUser();
+      final result = executeGuard(
+        mockUser,
+        isSplashFinished: false,
+      );
+      expect(result, const SplashRoute().location);
+    });
+
+    test('スプラッシュ完了後、スプラッシュ画面にいてログイン済みの場合、ホーム画面へリダイレクトすること', () {
+      final mockUser = MockUser();
+      final result = executeGuard(
+        mockUser,
+        location: const SplashRoute().location,
+      );
+      expect(result, const HomeRoute().location);
+    });
+
+    test('スプラッシュ完了後、スプラッシュ画面にいて未ログインの場合、ログイン画面へリダイレクトすること', () {
+      final result = executeGuard(
+        null,
+        location: const SplashRoute().location,
+      );
+      expect(result, const LoginRoute().location);
     });
   });
 }

--- a/test/src/features/splash/presentation/splash_screen_test.dart
+++ b/test/src/features/splash/presentation/splash_screen_test.dart
@@ -1,20 +1,54 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_screen.dart';
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
-  testWidgets('SplashScreen: スプラッシュ画面にインジケータが表示されること', (tester) async {
-    // 1. ウィジェットの構築（ProviderScopeやL10nのモックすら不要！）
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: SplashScreen(),
-      ),
-    );
+  group('SplashScreenのテスト', () {
+    testWidgets('初期表示のテスト: 背景グラデーションとロゴが表示されること', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: SplashScreen(),
+          ),
+        ),
+      );
 
-    // 2. 検証：CircularProgressIndicator が1つだけ存在するか
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // Scaffold が表示されていること
+      expect(find.byType(Scaffold), findsOneWidget);
 
-    // （おまけ）Scaffoldが土台として存在しているかも確認
-    expect(find.byType(Scaffold), findsOneWidget);
+      // SplashLogo が表示されていること
+      expect(find.byType(SplashLogo), findsOneWidget);
+
+      // ロゴ内のアイコンとテキストが表示されていること
+      expect(find.byIcon(Icons.flutter_dash), findsOneWidget);
+      expect(find.text('Flutter Sample App'), findsOneWidget);
+    });
+
+    testWidgets('2秒経過後に SplashState が完了（true）に更新されること', (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: SplashScreen(),
+          ),
+        ),
+      );
+
+      // 最初は false であること
+      expect(container.read(splashStateProvider), isFalse);
+
+      // 1秒経過（まだ false のはず）
+      await tester.pump(const Duration(seconds: 1));
+      expect(container.read(splashStateProvider), isFalse);
+
+      // さらに1.5秒経過（合計2.5秒。2秒を超えたため、完了になる）
+      await tester.pump(const Duration(milliseconds: 1500));
+      expect(container.read(splashStateProvider), isTrue);
+    });
   });
 }

--- a/test/src/features/splash/presentation/splash_screen_test.dart
+++ b/test/src/features/splash/presentation/splash_screen_test.dart
@@ -33,6 +33,11 @@ void main() {
   });
 
   group('SplashScreenのテスト', () {
+    test('コンストラクタでインスタンスが生成できること', () {
+      const screen = SplashScreen();
+      expect(screen, isNotNull);
+    });
+
     testWidgets('初期表示のテスト: 背景グラデーションとロゴが表示されること', (tester) async {
       // 画面サイズを固定し、テスト終了時にリセットする
       tester.view.physicalSize = const Size(1080, 1920);

--- a/test/src/features/splash/presentation/splash_screen_test.dart
+++ b/test/src/features/splash/presentation/splash_screen_test.dart
@@ -1,19 +1,62 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_screen.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+
+// --- モッククラスの定義 ---
+
+class MockAppLocalizations extends Mock implements AppLocalizations {}
+
+class _MockLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _MockLocalizationsDelegate(this.mock);
+  final MockAppLocalizations mock;
+  @override
+  bool isSupported(Locale locale) => true;
+  @override
+  Future<AppLocalizations> load(Locale locale) async => mock;
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) =>
+      false;
+}
 
 void main() {
+  late MockAppLocalizations mockL10n;
+
+  setUp(() {
+    mockL10n = MockAppLocalizations();
+    when(() => mockL10n.appTitle).thenReturn('Flutter Sample App');
+  });
+
   group('SplashScreenのテスト', () {
     testWidgets('初期表示のテスト: 背景グラデーションとロゴが表示されること', (tester) async {
+      // 画面サイズを固定し、テスト終了時にリセットする
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
       await tester.pumpWidget(
-        const ProviderScope(
+        ProviderScope(
           child: MaterialApp(
-            home: SplashScreen(),
+            localizationsDelegates: [
+              _MockLocalizationsDelegate(mockL10n),
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [Locale('ja')],
+            home: const SplashScreen(),
           ),
         ),
       );
+      await tester.pump();
 
       // Scaffold が表示されていること
       expect(find.byType(Scaffold), findsOneWidget);
@@ -27,17 +70,33 @@ void main() {
     });
 
     testWidgets('2秒経過後に SplashState が完了（true）に更新されること', (tester) async {
+      // 画面サイズを固定し、テスト終了時にリセットする
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
-          child: const MaterialApp(
-            home: SplashScreen(),
+          child: MaterialApp(
+            localizationsDelegates: [
+              _MockLocalizationsDelegate(mockL10n),
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [Locale('ja')],
+            home: const SplashScreen(),
           ),
         ),
       );
+      await tester.pump();
 
       // 最初は false であること
       expect(container.read(splashStateProvider), isFalse);

--- a/test/src/features/splash/presentation/splash_state_provider_test.dart
+++ b/test/src/features/splash/presentation/splash_state_provider_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  group('SplashStateProviderのテスト', () {
+    test('初期状態が false であること', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final splashState = container.read(splashStateProvider);
+      expect(splashState, isFalse);
+    });
+
+    test('finishSplash() を呼び出すと状態が true に変わること', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // 初期値を確認
+      expect(container.read(splashStateProvider), isFalse);
+
+      // 完了を通知
+      container.read(splashStateProvider.notifier).finishSplash();
+
+      // 変更後の値を確認
+      expect(container.read(splashStateProvider), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 📝 概要

- fvm を用いて splashStateProvider（コード生成含む）を新規追加
- splash_screen.dart を刷新し、flutter_hooks を利用したフェードイン＆バウンドアニメーションを実装
- アプリ起動から最低2秒間の表示と初期化完了を保証する遷移ロジックを実装
- スプラッシュ表示完了後に現在スプラッシュ画面にいる場合、ホームまたはログイン画面へ自動リダイレクトする処理を authGuard/firebaseAuthGuard に追加
- 関連するルーター周りのテストを修正・追加し、手動記述ファイルのカバレッジ100%を達成

## ✅ 確認事項

- [x] AI（Gemini Code Assist）によるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューはPR作成時に自動で行われますが、ドラフトの場合は実行されないのでドラフトを解除したタイミングで手動実行（`/gemini review`） すること
  - レビュー後に大幅な変更を行った場合は手動で再度レビューを実行（`/gemini review`） すること

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)
- [x] レビューアーに依頼する前にプルリクエストの要約（サマリー）をAIに作成（`/gemini summary`） してもらっているか

## ❕ 関連するIssue

Closes #127 
