### PR TITLE
test: テストの検証コードを package:checks へ移行

### DIFF
--- a/docs/api_and_error_handling.md
+++ b/docs/api_and_error_handling.md
@@ -101,7 +101,7 @@ await tester.pumpWidget(
 
 // 画面の描画を待って検証
 await tester.pumpAndSettle();
-expect(find.byType(Card), findsNWidgets(dummyUsers.length));
+check(find.byType(Card)).findsExactly(dummyUsers.length);
 ```
 
 このように、レイヤーを綺麗に分離することで、単体テストからウィジェットテストまで、カバレッジ100%を安全に達成できる構造になっています。

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -120,7 +120,7 @@ void main() {
       ),
     );
 
-    expect(find.text('Test Title'), findsOneWidget);
+    check(find.text('Test Title')).findsOne();
   });
 }
 ```

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -139,7 +139,7 @@ void main() {
     });
 
     test('schemaVersion returns 1', () {
-      expect(database.schemaVersion, 1);
+      check(database.schemaVersion).equals(1);
     });
 
     // ... その他のテストケース

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -80,7 +80,7 @@ test('テーマモードを変更すると状態が更新されること', () as
   final notifier = container.read(themeModeProvider.notifier);
 
   await notifier.setThemeMode(ThemeMode.dark);
-  expect(container.read(themeModeProvider), ThemeMode.dark);
+  check(container.read(themeModeProvider)).equals(ThemeMode.dark);
 });
 ```
 

--- a/lib/src/app/router/routes/shell_routes.dart
+++ b/lib/src/app/router/routes/shell_routes.dart
@@ -63,29 +63,29 @@ class AppShellRouteData extends StatefulShellRouteData {
 /// 🏠 ホームタブのブランチデータ
 class HomeBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const HomeBranch(); // coverage:ignore-line
+  const HomeBranch();
 }
 
 /// 🤖 チャットタブのブランチデータ
 class ChatBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const ChatBranch(); // coverage:ignore-line
+  const ChatBranch();
 }
 
 /// 📝 メモタブのブランチデータ
 class MemosBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const MemosBranch(); // coverage:ignore-line
+  const MemosBranch();
 }
 
 /// 📊 グラフタブのブランチデータ
 class ChartBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const ChartBranch(); // coverage:ignore-line
+  const ChartBranch();
 }
 
 /// 👥 ユーザー一覧タブのブランチデータ
 class UserBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const UserBranch(); // coverage:ignore-line
+  const UserBranch();
 }

--- a/lib/src/app/router/routes/shell_routes.dart
+++ b/lib/src/app/router/routes/shell_routes.dart
@@ -63,29 +63,29 @@ class AppShellRouteData extends StatefulShellRouteData {
 /// 🏠 ホームタブのブランチデータ
 class HomeBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const HomeBranch();
+  const HomeBranch(); // coverage:ignore-line
 }
 
 /// 🤖 チャットタブのブランチデータ
 class ChatBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const ChatBranch();
+  const ChatBranch(); // coverage:ignore-line
 }
 
 /// 📝 メモタブのブランチデータ
 class MemosBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const MemosBranch();
+  const MemosBranch(); // coverage:ignore-line
 }
 
 /// 📊 グラフタブのブランチデータ
 class ChartBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const ChartBranch();
+  const ChartBranch(); // coverage:ignore-line
 }
 
 /// 👥 ユーザー一覧タブのブランチデータ
 class UserBranch extends StatefulShellBranchData {
   /// コンストラクタ
-  const UserBranch();
+  const UserBranch(); // coverage:ignore-line
 }

--- a/lib/src/core/config/app_theme.dart
+++ b/lib/src/core/config/app_theme.dart
@@ -2,9 +2,7 @@ import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 
 /// アプリ全体のテーマ設定をまとめたクラス
-class AppTheme {
-  AppTheme._(); // coverage:ignore-line
-
+abstract final class AppTheme {
   // ベースとなる色（お好みでOK）
   // static const _seed = Color(0xFF4F46E5); // indigo-ish
 

--- a/lib/src/core/exceptions/firebase_auth_error_codes.dart
+++ b/lib/src/core/exceptions/firebase_auth_error_codes.dart
@@ -2,9 +2,7 @@
 ///
 /// `FirebaseAuthException` の `code` プロパティと照合するために使用します。
 /// 公式リファレンス: https://firebase.google.com/docs/auth/admin/errors
-class FirebaseAuthErrorCodes {
-  FirebaseAuthErrorCodes._(); // coverage:ignore-line
-
+abstract final class FirebaseAuthErrorCodes {
   /// メールアドレスの形式が不正な場合にスローされます。
   /// （例: `@` が含まれていない、ドメインがない など）
   static const invalidEmail = 'invalid-email';

--- a/lib/src/core/ui/error_handler.dart
+++ b/lib/src/core/ui/error_handler.dart
@@ -9,9 +9,7 @@ import 'package:flutter_sample/src/core/ui/snackbar_extension.dart';
 import 'package:go_router/go_router.dart';
 
 /// エラーをSnackbarまたはDialogで表示する共通関数群
-class ErrorHandler {
-  ErrorHandler._(); // coverage:ignore-line
-
+abstract final class ErrorHandler {
   /// 共通メッセージ変換
   static String message(BuildContext context, Object error) {
     final l10n = context.l10n;

--- a/lib/src/core/widgets/version_up_dialog.dart
+++ b/lib/src/core/widgets/version_up_dialog.dart
@@ -3,10 +3,7 @@ import 'package:flutter_sample/src/core/ui/l10n_extension.dart';
 import 'package:go_router/go_router.dart';
 
 /// バージョンアップダイアログの表示
-class VersionUpDialog {
-  // インスタンス化を防止するプライベートコンストラクタ
-  VersionUpDialog._(); // coverage:ignore-line
-
+abstract final class VersionUpDialog {
   /// バージョンアップダイアログを表示
   ///
   /// [isCancelable] が true の場合、キャンセルボタンを表示し、ダイアログ外タップでも閉じられます。

--- a/lib/src/features/auth/presentation/firebase_login_screen.dart
+++ b/lib/src/features/auth/presentation/firebase_login_screen.dart
@@ -9,7 +9,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// Firebase版ログイン画面
 class FirebaseLoginScreen extends HookConsumerWidget {
   /// コンストラクタ
-  const FirebaseLoginScreen({super.key}); // coverage:ignore-line
+  const FirebaseLoginScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/features/auth/presentation/firebase_reset_password_screen.dart
+++ b/lib/src/features/auth/presentation/firebase_reset_password_screen.dart
@@ -10,7 +10,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// パスワードのリセットメールを送信する画面
 class FirebaseResetPasswordScreen extends HookConsumerWidget {
   /// コンストラクタ
-  const FirebaseResetPasswordScreen({super.key}); // coverage:ignore-line
+  const FirebaseResetPasswordScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/features/auth/presentation/firebase_sign_up_screen.dart
+++ b/lib/src/features/auth/presentation/firebase_sign_up_screen.dart
@@ -9,7 +9,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// Firebase版のサインアップ画面
 class FirebaseSignUpScreen extends HookConsumerWidget {
   /// コンストラクタ
-  const FirebaseSignUpScreen({super.key}); // coverage:ignore-line
+  const FirebaseSignUpScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/features/auth/presentation/login_screen.dart
+++ b/lib/src/features/auth/presentation/login_screen.dart
@@ -11,7 +11,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// ログイン画面
 class LoginScreen extends HookConsumerWidget {
   /// コンストラクタ
-  const LoginScreen({super.key}); // coverage:ignore-line
+  const LoginScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/features/chat/domain/chat_message.dart
+++ b/lib/src/features/chat/domain/chat_message.dart
@@ -5,7 +5,7 @@ part 'chat_message.freezed.dart';
 /// チャットメッセージのクラス
 @freezed
 sealed class ChatMessage with _$ChatMessage {
-  const ChatMessage._(); // coverage:ignore-line
+  const ChatMessage._();
 
   /// ユーザーの送信メッセージ
   const factory ChatMessage.user({

--- a/lib/src/features/memos/presentation/memo_screen.dart
+++ b/lib/src/features/memos/presentation/memo_screen.dart
@@ -10,7 +10,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// メモ画面
 class MemoScreen extends ConsumerWidget {
   /// コンストラクタ
-  const MemoScreen({super.key}); // coverage:ignore-line
+  const MemoScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  checks:
+    dependency: "direct dev"
+    description:
+      name: checks
+      sha256: "016871c84732c1ac9856b8940236d5a5802ba638b3bd3e0ea7027b51a35f7aa7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   ci:
     dependency: transitive
     description:
@@ -582,6 +590,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_checks:
+    dependency: "direct dev"
+    description:
+      name: flutter_checks
+      sha256: "800acdd6973e1306f65ef3b2287d91c0e45c8e64b696d593297c0c1c1e2740bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   flutter_flavorizr:
     dependency: "direct dev"
     description:
@@ -925,6 +941,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  legacy_checks:
+    dependency: "direct dev"
+    description:
+      name: legacy_checks
+      sha256: "1322d6f15e27c214b225d32c9802cd8d312a0373a45efccf48e5e2bb42c7611b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -114,6 +114,11 @@ dev_dependencies:
   flutter_flavorizr: ^2.2.3 # Flavorの自動構成ツール
   flutter_launcher_icons: ^0.13.1 # アイコン生成ツール（Flavor対応用）
 
+  # --- テスト関連 ---
+  checks: ^0.3.1
+  flutter_checks: ^0.1.2
+  legacy_checks: ^0.1.1
+
 # -----------------------------------------------
 # 🎯 Flutter固有の設定
 # -----------------------------------------------

--- a/test/src/app/database/app_database_test.dart
+++ b/test/src/app/database/app_database_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_sample/src/app/database/app_database.dart';
@@ -22,7 +23,7 @@ void main() {
     });
 
     test('schemaVersion returns 1', () {
-      expect(database.schemaVersion, 1);
+      check(database.schemaVersion).equals(1);
     });
 
     test('onUpgrade migration strategy executes without error', () async {
@@ -40,7 +41,7 @@ void main() {
       // beforeOpen も同様
       await strategy.beforeOpen?.call(const OpeningDetails(null, 1));
 
-      expect(true, isTrue); // ここまで到達すればOK
+      check(true).equals(true); // ここまで到達すればOK
     });
 
     test('テーブル操作の基本テスト (CRUD)', () async {
@@ -59,12 +60,12 @@ void main() {
 
       // Read
       var memos = await database.select(database.memos).get();
-      expect(memos.length, 1);
-      expect(memos.first.id, 'test-id-1');
-      expect(memos.first.title, 'テストタイトル');
-      expect(memos.first.content, 'テストコンテンツ');
-      expect(memos.first.createdAt, DateTime(2026, 5));
-      expect(memos.first.updatedAt, DateTime(2026, 5));
+      check(memos.length).equals(1);
+      check(memos.first.id).equals('test-id-1');
+      check(memos.first.title).equals('テストタイトル');
+      check(memos.first.content).equals('テストコンテンツ');
+      check(memos.first.createdAt).equals(DateTime(2026, 5));
+      check(memos.first.updatedAt).equals(DateTime(2026, 5));
 
       // Update
       await database
@@ -73,12 +74,12 @@ void main() {
             memos.first.copyWith(title: '更新されたタイトル'),
           );
       memos = await database.select(database.memos).get();
-      expect(memos.first.title, '更新されたタイトル');
+      check(memos.first.title).equals('更新されたタイトル');
 
       // Delete
       await database.delete(database.memos).delete(memos.first);
       memos = await database.select(database.memos).get();
-      expect(memos.isEmpty, true);
+      check(memos.isEmpty).equals(true);
     });
   });
 }

--- a/test/src/app/router/app_router_test.dart
+++ b/test/src/app/router/app_router_test.dart
@@ -1,9 +1,8 @@
-// We need to instantiate branch data classes without const
-// so that their constructor code execution is counted in test coverage.
-// ignore_for_file: prefer_const_constructors
+import 'package:checks/checks.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/app/router/app_router.dart';
@@ -214,7 +213,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.byType(HomeScreen), findsOneWidget);
+      check(find.byType(HomeScreen)).findsOne();
       await teardownWidget(tester, container);
     });
 
@@ -227,7 +226,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.byType(LoginScreen), findsOneWidget);
+      check(find.byType(LoginScreen)).findsOne();
       await teardownWidget(tester, container);
     });
 
@@ -240,7 +239,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.byType(FirebaseLoginScreen), findsOneWidget);
+      check(find.byType(FirebaseLoginScreen)).findsOne();
       await teardownWidget(tester, container);
     });
 
@@ -257,7 +256,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 200));
       }
 
-      expect(find.byType(NotFoundScreen), findsOneWidget);
+      check(find.byType(NotFoundScreen)).findsOne();
       await teardownWidget(tester, container);
     });
 
@@ -268,7 +267,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // 最初は未ログインなので FirebaseLoginScreen が表示されていること
-      expect(find.byType(FirebaseLoginScreen), findsOneWidget);
+      check(find.byType(FirebaseLoginScreen)).findsOne();
 
       // firebaseAuthStateProvider の状態を強制的に変更する
       (container.read(firebaseAuthStateProvider.notifier)
@@ -279,7 +278,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // ログイン状態になったので HomeScreen に遷移することを確認
-      expect(find.byType(HomeScreen), findsOneWidget);
+      check(find.byType(HomeScreen)).findsOne();
 
       await teardownWidget(tester, container);
     });
@@ -295,14 +294,14 @@ void main() {
       await tester.pump();
 
       // 最初はスプラッシュ未完了なので SplashScreen が表示されていること
-      expect(find.byType(SplashScreen), findsOneWidget);
+      check(find.byType(SplashScreen)).findsOne();
 
       // スプラッシュ完了状態にする
       container.read(splashStateProvider.notifier).finishSplash();
       await tester.pumpAndSettle();
 
       // スプラッシュが完了したので HomeScreen に遷移すること
-      expect(find.byType(HomeScreen), findsOneWidget);
+      check(find.byType(HomeScreen)).findsOne();
 
       await teardownWidget(tester, container);
     });
@@ -320,7 +319,7 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(seconds: 1));
 
-        expect(find.byType(FirebaseEmailVerificationScreen), findsOneWidget);
+        check(find.byType(FirebaseEmailVerificationScreen)).findsOne();
         await teardownWidget(tester, container);
       },
     );
@@ -336,7 +335,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.byType(FirebaseEmailVerificationScreen), findsOneWidget);
+      check(find.byType(FirebaseEmailVerificationScreen)).findsOne();
 
       final verifiedUser = MockUser();
       when(() => verifiedUser.uid).thenReturn('dummy_uid_123');
@@ -356,7 +355,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.byType(HomeScreen), findsOneWidget);
+      check(find.byType(HomeScreen)).findsOne();
       await teardownWidget(tester, container);
     });
 
@@ -369,7 +368,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.byType(HomeScreen), findsOneWidget);
+      check(find.byType(HomeScreen)).findsOne();
 
       (container.read(firebaseAuthStateProvider.notifier)
               as _FakeFirebaseAuthStateNotifier)
@@ -378,7 +377,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      expect(find.byType(FirebaseLoginScreen), findsOneWidget);
+      check(find.byType(FirebaseLoginScreen)).findsOne();
       await teardownWidget(tester, container);
     });
   });
@@ -429,7 +428,7 @@ void main() {
       );
 
       await tester.pump();
-      expect(find.byType(FirebaseLoginScreen), findsOneWidget);
+      check(find.byType(FirebaseLoginScreen)).findsOne();
 
       await teardownWidget(tester, container);
     });
@@ -439,7 +438,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<HomeScreen>());
+      check(widget).isA<HomeScreen>();
     });
 
     test('SettingsRoute.build: SettingsScreen を返すこと', () {
@@ -447,7 +446,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<SettingsScreen>());
+      check(widget).isA<SettingsScreen>();
     });
 
     test('UserListRoute.build: UserListScreen を返すこと', () {
@@ -455,7 +454,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<UserListScreen>());
+      check(widget).isA<UserListScreen>();
     });
 
     test('ChatRoute.build: ChatScreen を返すこと', () {
@@ -463,7 +462,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<ChatScreen>());
+      check(widget).isA<ChatScreen>();
     });
 
     test('ChartInputRoute.build: ChartInputScreen を返すこと', () {
@@ -471,7 +470,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<ChartInputScreen>());
+      check(widget).isA<ChartInputScreen>();
     });
 
     test('ChartDisplayRoute.build: ChartDisplayScreen を返すこと', () {
@@ -479,7 +478,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<ChartDisplayScreen>());
+      check(widget).isA<ChartDisplayScreen>();
     });
 
     test('MemosRoute.build: MemoScreen を返すこと', () {
@@ -487,7 +486,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<MemoScreen>());
+      check(widget).isA<MemoScreen>();
     });
 
     test('SplashRoute.build: SplashScreen を返すこと', () {
@@ -495,7 +494,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<SplashScreen>());
+      check(widget).isA<SplashScreen>();
     });
 
     test('SignUpRoute.build: FirebaseSignUpScreen を返すこと', () {
@@ -503,7 +502,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<FirebaseSignUpScreen>());
+      check(widget).isA<FirebaseSignUpScreen>();
     });
 
     test('ResetPasswordRoute.build: FirebaseResetPasswordScreen を返すこと', () {
@@ -511,7 +510,7 @@ void main() {
         MockBuildContext(),
         MockGoRouterState(),
       );
-      expect(widget, isA<FirebaseResetPasswordScreen>());
+      check(widget).isA<FirebaseResetPasswordScreen>();
     });
 
     test(
@@ -521,7 +520,7 @@ void main() {
           MockBuildContext(),
           MockGoRouterState(),
         );
-        expect(widget, isA<FirebaseEmailVerificationScreen>());
+        check(widget).isA<FirebaseEmailVerificationScreen>();
       },
     );
 
@@ -532,27 +531,27 @@ void main() {
         MockGoRouterState(),
         mockShell,
       );
-      expect(widget, isA<MainShellScreen>());
+      check(widget).isA<MainShellScreen>();
     });
 
     test('HomeBranch: インスタンス化できること', () {
-      expect(HomeBranch(), isNotNull);
+      check(const HomeBranch()).isNotNull();
     });
 
     test('ChatBranch: インスタンス化できること', () {
-      expect(ChatBranch(), isNotNull);
+      check(const ChatBranch()).isNotNull();
     });
 
     test('MemosBranch: インスタンス化できること', () {
-      expect(MemosBranch(), isNotNull);
+      check(const MemosBranch()).isNotNull();
     });
 
     test('ChartBranch: インスタンス化できること', () {
-      expect(ChartBranch(), isNotNull);
+      check(const ChartBranch()).isNotNull();
     });
 
     test('UserBranch: インスタンス化できること', () {
-      expect(UserBranch(), isNotNull);
+      check(const UserBranch()).isNotNull();
     });
   });
 
@@ -627,32 +626,21 @@ void main() {
       await tester.pumpAndSettle();
 
       // 初期表示は HomeScreen が表示されていること
-      expect(find.byType(MainShellScreen), findsOneWidget);
-      expect(find.byType(HomeScreen), findsOneWidget);
+      check(find.byType(MainShellScreen)).findsOne();
+      check(find.byType(HomeScreen)).findsOne();
 
       // 各タブが表示されていることの確認（NavigationBar内のテキストを検索）
-      expect(find.byType(NavigationBar), findsOneWidget);
+      check(find.byType(NavigationBar)).findsOne();
       final navBar = find.byType(NavigationBar);
-      expect(
-        find.descendant(of: navBar, matching: find.text('ホーム')),
-        findsOneWidget,
-      );
-      expect(
+      check(find.descendant(of: navBar, matching: find.text('ホーム'))).findsOne();
+      check(
         find.descendant(of: navBar, matching: find.text('チャット')),
-        findsOneWidget,
-      );
-      expect(
-        find.descendant(of: navBar, matching: find.text('メモ')),
-        findsOneWidget,
-      );
-      expect(
-        find.descendant(of: navBar, matching: find.text('グラフ')),
-        findsOneWidget,
-      );
-      expect(
+      ).findsOne();
+      check(find.descendant(of: navBar, matching: find.text('メモ'))).findsOne();
+      check(find.descendant(of: navBar, matching: find.text('グラフ'))).findsOne();
+      check(
         find.descendant(of: navBar, matching: find.text('ユーザー')),
-        findsOneWidget,
-      );
+      ).findsOne();
 
       // チャットタブ（インデックス1）をタップする
       await tester.tap(
@@ -661,7 +649,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // ChatScreen に切り替わっていることを確認
-      expect(find.byType(ChatScreen), findsOneWidget);
+      check(find.byType(ChatScreen)).findsOne();
 
       // 同じチャットタブを再度タップする（initialLocation: true の分岐をテストするため）
       await tester.tap(
@@ -674,7 +662,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // MemoScreen に切り替わっていることを確認
-      expect(find.byType(MemoScreen), findsOneWidget);
+      check(find.byType(MemoScreen)).findsOne();
 
       await teardownWidget(tester, container);
     });

--- a/test/src/app/router/app_router_test.dart
+++ b/test/src/app/router/app_router_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors, document_ignores
 import 'package:checks/checks.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -535,23 +536,23 @@ void main() {
     });
 
     test('HomeBranch: インスタンス化できること', () {
-      check(const HomeBranch()).isNotNull();
+      check(HomeBranch()).isNotNull();
     });
 
     test('ChatBranch: インスタンス化できること', () {
-      check(const ChatBranch()).isNotNull();
+      check(ChatBranch()).isNotNull();
     });
 
     test('MemosBranch: インスタンス化できること', () {
-      check(const MemosBranch()).isNotNull();
+      check(MemosBranch()).isNotNull();
     });
 
     test('ChartBranch: インスタンス化できること', () {
-      check(const ChartBranch()).isNotNull();
+      check(ChartBranch()).isNotNull();
     });
 
     test('UserBranch: インスタンス化できること', () {
-      check(const UserBranch()).isNotNull();
+      check(UserBranch()).isNotNull();
     });
   });
 

--- a/test/src/app/router/auth_guard_test.dart
+++ b/test/src/app/router/auth_guard_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart'; // SynchronousFuture 用
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/auth_guard.dart';
@@ -80,7 +81,7 @@ void main() {
   group('authGuard の状態ハンドリングテスト', () {
     test('認証状態が Loading の場合、SplashRoute にリダイレクトすること', () {
       final result = executeGuard(const AsyncLoading<bool>());
-      expect(result, const SplashRoute().location);
+      check(result).equals(const SplashRoute().location);
     });
 
     test('ログイン済み（Data: true）の場合、ログイン画面からホームへリダイレクトすること', () {
@@ -88,7 +89,7 @@ void main() {
         const AsyncData<bool>(true),
         location: const LoginRoute().location,
       );
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
 
     test('ログイン済み（Data: true）で、すでにホームにいる場合、リダイレクトしないこと', () {
@@ -96,7 +97,7 @@ void main() {
         const AsyncData<bool>(true),
         location: const HomeRoute().location,
       );
-      expect(result, isNull);
+      check(result).isNull();
     });
 
     test('未ログイン（Data: false）の場合、ホームからログイン画面にリダイレクトすること', () {
@@ -104,8 +105,8 @@ void main() {
         const AsyncData<bool>(false),
         location: const HomeRoute().location,
       );
-      expect(result, startsWith(const LoginRoute().location));
-      expect(result, contains('from=${Uri.encodeComponent('/')}'));
+      check(result).isNotNull().startsWith(const LoginRoute().location);
+      check(result).isNotNull().contains('from=${Uri.encodeComponent('/')}');
     });
 
     test('未ログイン（Data: false）で、すでにログイン画面にいる場合、リダイレクトしないこと', () {
@@ -113,7 +114,7 @@ void main() {
         const AsyncData<bool>(false),
         location: const LoginRoute().location,
       );
-      expect(result, isNull);
+      check(result).isNull();
     });
 
     test('認証状態でエラーが発生した場合、未ログイン扱いとしてログイン画面にリダイレクトすること', () {
@@ -121,8 +122,8 @@ void main() {
         AsyncValue<bool>.error(Exception('Auth Error'), StackTrace.empty),
         location: const HomeRoute().location,
       );
-      expect(result, startsWith(const LoginRoute().location));
-      expect(result, contains('from=${Uri.encodeComponent('/')}'));
+      check(result).isNotNull().startsWith(const LoginRoute().location);
+      check(result).isNotNull().contains('from=${Uri.encodeComponent('/')}');
     });
 
     test('スプラッシュ未完了の場合、常に SplashRoute にリダイレクトすること', () {
@@ -130,7 +131,7 @@ void main() {
         const AsyncData<bool>(true),
         isSplashFinished: false,
       );
-      expect(result, const SplashRoute().location);
+      check(result).equals(const SplashRoute().location);
     });
 
     test('スプラッシュ完了後、スプラッシュ画面にいて未ログインの場合、ログイン画面へリダイレクトすること', () {
@@ -138,7 +139,7 @@ void main() {
         const AsyncData<bool>(false),
         location: const SplashRoute().location,
       );
-      expect(result, const LoginRoute().location);
+      check(result).equals(const LoginRoute().location);
     });
 
     test('スプラッシュ完了後、スプラッシュ画面にいてログイン済みの場合、ホーム画面へリダイレクトすること', () {
@@ -146,7 +147,7 @@ void main() {
         const AsyncData<bool>(true),
         location: const SplashRoute().location,
       );
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
   });
 }

--- a/test/src/app/router/base_auth_guard_test.dart
+++ b/test/src/app/router/base_auth_guard_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/base_auth_guard.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -41,8 +42,10 @@ void main() {
 
       // Assert
       // '/login?from=%2F' のような形式になるはず
-      expect(result, contains(const LoginRoute().location));
-      expect(result, contains('from=${Uri.encodeComponent(destination)}'));
+      check(result).isNotNull().contains(const LoginRoute().location);
+      check(
+        result,
+      ).isNotNull().contains('from=${Uri.encodeComponent(destination)}');
     });
 
     test('未ログインでもゲスト専用画面（サインアップ）に行こうとした場合、リダイレクトしないこと', () {
@@ -53,7 +56,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: false, state: mockState);
 
       // Assert
-      expect(result, isNull);
+      check(result).isNull();
     });
 
     test('未ログインでも常に公開されている画面（スプラッシュ）に行こうとした場合、リダイレクトしないこと', () {
@@ -64,7 +67,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: false, state: mockState);
 
       // Assert
-      expect(result, isNull);
+      check(result).isNull();
     });
 
     test('ログイン済みでゲスト専用画面（ログイン画面）に行こうとした場合、ホームにリダイレクトすること', () {
@@ -75,7 +78,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: true, state: mockState);
 
       // Assert
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
 
     test('ログイン済みかつfromパラメータがある状態でゲスト専用画面に行こうとした場合、fromの場所へリダイレクトすること', () {
@@ -87,7 +90,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: true, state: mockState);
 
       // Assert
-      expect(result, fromPath);
+      check(result).equals(fromPath);
     });
 
     test('【セキュリティ】ログイン済みでfromに外部サイト(http)が指定された場合、無視してホームにリダイレクトすること', () {
@@ -99,7 +102,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: true, state: mockState);
 
       // Assert
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
 
     test('【セキュリティ】ログイン済みでfromに外部サイト(//)が指定された場合、無視してホームにリダイレクトすること', () {
@@ -111,7 +114,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: true, state: mockState);
 
       // Assert
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
 
     test('【無限ループ防止】ログイン済みでfromにゲスト専用画面(/login)が指定された場合、無視してホームにリダイレクトすること', () {
@@ -123,7 +126,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: true, state: mockState);
 
       // Assert
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
 
     test('ログイン済みで認証必須画面（ホーム）に行く場合、リダイレクトしないこと', () {
@@ -134,7 +137,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: true, state: mockState);
 
       // Assert
-      expect(result, isNull);
+      check(result).isNull();
     });
 
     test('ログイン済みで常に公開されている画面（スプラッシュ）に行く場合、リダイレクトしないこと', () {
@@ -145,7 +148,7 @@ void main() {
       final result = helper.redirect(isLoggedIn: true, state: mockState);
 
       // Assert
-      expect(result, isNull);
+      check(result).isNull();
     });
   });
 }

--- a/test/src/app/router/firebase_auth_guard_test.dart
+++ b/test/src/app/router/firebase_auth_guard_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/firebase_auth_guard.dart';
@@ -57,7 +58,7 @@ void main() {
 
       final result = executeGuard(mockUser);
 
-      expect(result, const EmailVerificationRoute().location);
+      check(result).equals(const EmailVerificationRoute().location);
     });
 
     test('ログイン済みかつメール未認証だが、すでにメール認証画面にいる場合はリダイレクトしないこと', () {
@@ -70,7 +71,7 @@ void main() {
       );
 
       // AuthGuardHelper.redirect に判定が移る（この場合は null が期待される）
-      expect(result, isNull);
+      check(result).isNull();
     });
 
     test('ログイン済みかつメール認証済みの場合、AuthGuardHelper に判定が委譲されること', () {
@@ -84,7 +85,7 @@ void main() {
       );
 
       // AuthGuardHelper によりホームへリダイレクトされることを確認
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
 
     test('未ログインの場合、AuthGuardHelper に判定が委譲されること', () {
@@ -92,8 +93,8 @@ void main() {
       final result = executeGuard(null);
 
       // AuthGuardHelper によりログイン画面へリダイレクトされることを確認（fromパラメータ付き）
-      expect(result, startsWith(const LoginRoute().location));
-      expect(result, contains('from=${Uri.encodeComponent('/')}'));
+      check(result).isNotNull().startsWith(const LoginRoute().location);
+      check(result).isNotNull().contains('from=${Uri.encodeComponent('/')}');
     });
 
     test('スプラッシュ未完了の場合、常に SplashRoute にリダイレクトすること', () {
@@ -102,7 +103,7 @@ void main() {
         mockUser,
         isSplashFinished: false,
       );
-      expect(result, const SplashRoute().location);
+      check(result).equals(const SplashRoute().location);
     });
 
     test('スプラッシュ完了後、スプラッシュ画面にいてログイン済みの場合、ホーム画面へリダイレクトすること', () {
@@ -111,7 +112,7 @@ void main() {
         mockUser,
         location: const SplashRoute().location,
       );
-      expect(result, const HomeRoute().location);
+      check(result).equals(const HomeRoute().location);
     });
 
     test('スプラッシュ完了後、スプラッシュ画面にいて未ログインの場合、ログイン画面へリダイレクトすること', () {
@@ -119,7 +120,7 @@ void main() {
         null,
         location: const SplashRoute().location,
       );
-      expect(result, const LoginRoute().location);
+      check(result).equals(const LoginRoute().location);
     });
   });
 }

--- a/test/src/app/router/snackbar_navigation_observer_test.dart
+++ b/test/src/app/router/snackbar_navigation_observer_test.dart
@@ -1,7 +1,10 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/src/app/router/snackbar_navigation_observer.dart';
 import 'package:flutter_sample/src/core/utils/scaffold_messenger_key.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 
 /// [PageRoute] のモッククラス
@@ -32,13 +35,13 @@ void main() {
         const SnackBar(content: Text('Test SnackBar')),
       );
       await tester.pump();
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
 
       // PageRoute の遷移をシミュレート
       observer.didPush(MockPageRoute(), null);
 
       await tester.pump();
-      expect(find.byType(SnackBar), findsNothing);
+      check(find.byType(SnackBar)).findsNothing();
     });
 
     testWidgets('【正常系】didPop の際に PageRoute であれば clearSnackBars が呼ばれること', (
@@ -55,13 +58,13 @@ void main() {
         const SnackBar(content: Text('Test SnackBar')),
       );
       await tester.pump();
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
 
       // PageRoute の遷移をシミュレート
       observer.didPop(MockPageRoute(), null);
 
       await tester.pump();
-      expect(find.byType(SnackBar), findsNothing);
+      check(find.byType(SnackBar)).findsNothing();
     });
 
     testWidgets('【正常系】didReplace の際に PageRoute であれば clearSnackBars が呼ばれること', (
@@ -78,13 +81,13 @@ void main() {
         const SnackBar(content: Text('Test SnackBar')),
       );
       await tester.pump();
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
 
       // PageRoute の置換をシミュレート
       observer.didReplace(newRoute: MockPageRoute());
 
       await tester.pump();
-      expect(find.byType(SnackBar), findsNothing);
+      check(find.byType(SnackBar)).findsNothing();
     });
 
     testWidgets('【ガード】PopupRoute（ダイアログ等）の遷移ではスナックバーが消えないこと', (tester) async {
@@ -99,14 +102,14 @@ void main() {
         const SnackBar(content: Text('Test SnackBar')),
       );
       await tester.pump();
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
 
       // PopupRoute の遷移をシミュレート
       observer.didPush(MockPopupRoute(), null);
 
       await tester.pump();
       // まだ表示されているはず
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
     });
 
     test('currentState が null の場合にエラーにならないこと', () {
@@ -114,10 +117,9 @@ void main() {
       final dummyKey = GlobalKey<ScaffoldMessengerState>();
       final dummyObserver = SnackBarNavigationObserver(dummyKey);
 
-      expect(
+      check(
         () => dummyObserver.didPush(MockPageRoute(), null),
-        returnsNormally,
-      );
+      ).legacyMatcher(returnsNormally);
     });
   });
 }

--- a/test/src/core/analytics/analytics_event_test.dart
+++ b/test/src/core/analytics/analytics_event_test.dart
@@ -1,21 +1,21 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/analytics/analytics_event.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AnalyticsEvent テスト', () {
     test('定義されているAnalyticsイベントの数が正確に5つであること', () {
-      expect(AnalyticsEvent.values.length, 5);
+      check(AnalyticsEvent.values.length).equals(5);
     });
 
     test('各enumが正しいイベント名(文字列)を保持していること', () {
-      expect(AnalyticsEvent.appStarted.name, 'app_started');
-      expect(
+      check(AnalyticsEvent.appStarted.name).equals('app_started');
+      check(
         AnalyticsEvent.homeButtonTapped.name,
-        'home_analytics_button_tapped',
-      );
-      expect(AnalyticsEvent.loginSuccess.name, 'login_success');
-      expect(AnalyticsEvent.logout.name, 'logout');
-      expect(AnalyticsEvent.errorOccurred.name, 'error_occurred');
+      ).equals('home_analytics_button_tapped');
+      check(AnalyticsEvent.loginSuccess.name).equals('login_success');
+      check(AnalyticsEvent.logout.name).equals('logout');
+      check(AnalyticsEvent.errorOccurred.name).equals('error_occurred');
     });
   });
 }

--- a/test/src/core/analytics/analytics_service_test.dart
+++ b/test/src/core/analytics/analytics_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter_sample/src/core/analytics/analytics_event.dart';
 import 'package:flutter_sample/src/core/analytics/analytics_service.dart';
@@ -74,19 +75,19 @@ void main() {
           ),
         ).captured;
 
-        expect(captured[0], 'login_success');
+        check(captured[0]).equals('login_success');
 
         final params = captured[1] as Map<String, Object>;
 
         // ① 正常な値が渡されているか
-        expect(params['user_id'], 123);
-        expect(params['user_type'], 'premium');
+        check(params['user_id']).equals(123);
+        check(params['user_type']).equals('premium');
 
         // ② null の値が正しく除外されているか
-        expect(params.containsKey('null_value'), isFalse);
+        check(params.containsKey('null_value')).equals(false);
 
         // ③ 【進化ポイント】timestamp がモックで固定した日時と「完全に一致」しているか！
-        expect(params['timestamp'], mockDateTime.millisecondsSinceEpoch);
+        check(params['timestamp']).equals(mockDateTime.millisecondsSinceEpoch);
       },
     );
 
@@ -103,10 +104,9 @@ void main() {
 
       // Act & Assert
       // 例外が内部で catch され、メソッドがエラーを外に漏らさず正常終了(completes)することを確認
-      await expectLater(
+      await check(
         service.logEvent(event: AnalyticsEvent.loginSuccess),
-        completes,
-      );
+      ).completes();
     });
 
     test('setUserId が正しいIDで呼び出されること', () async {
@@ -150,7 +150,7 @@ void main() {
       final service = container.read(analyticsServiceProvider);
 
       // Act & Assert
-      await expectLater(service.setUserId('user_123'), completes);
+      await check(service.setUserId('user_123')).completes();
       verify(
         () => mockTalker.warning(
           any<String>(that: contains('SetUserId Error')),
@@ -169,10 +169,9 @@ void main() {
       final service = container.read(analyticsServiceProvider);
 
       // Act & Assert
-      await expectLater(
+      await check(
         service.setUserProperty(name: 'plan', value: 'gold'),
-        completes,
-      );
+      ).completes();
       verify(
         () => mockTalker.warning(
           any<String>(that: contains('SetUserProperty Error')),
@@ -214,7 +213,7 @@ void main() {
       ).captured;
 
       final params = captured.first as Map<String, Object>;
-      expect(params['timestamp'], fixedDate.millisecondsSinceEpoch);
+      check(params['timestamp']).equals(fixedDate.millisecondsSinceEpoch);
     });
   });
 }

--- a/test/src/core/config/app_config_provider_test.dart
+++ b/test/src/core/config/app_config_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/core/config/app_config_provider.dart';
@@ -51,9 +52,9 @@ void main() {
 
       // Assert (検証)
       // Record の各プロパティ（名前付きフィールド）がダミー値と完全に一致するか確認します
-      expect(config.router, equals(dummyRouter));
-      expect(config.theme, equals(dummyTheme));
-      expect(config.locale, equals(dummyLocale));
+      check(config.router).equals(dummyRouter);
+      check(config.theme).equals(dummyTheme);
+      check(config.locale).equals(dummyLocale);
     });
   });
 }

--- a/test/src/core/config/app_env_test.dart
+++ b/test/src/core/config/app_env_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/config/app_env.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,10 +10,10 @@ void main() {
       // Arrange & Act & Assert
 
       // App Checkのデバッグトークン（秘匿情報）が取得できること
-      expect(AppEnv.debugToken, isA<String>());
+      check(AppEnv.debugToken).isA<String>();
 
       // Google 逆クライアント ID（秘匿情報）が取得できること
-      expect(AppEnv.googleReversedClientId, isA<String>());
+      check(AppEnv.googleReversedClientId).isA<String>();
 
       // 認証設定のProviderが真偽値を返すこと
       final container = ProviderContainer(
@@ -30,7 +31,7 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-      expect(container.read(envConfigProvider).useFirebaseAuth, isA<bool>());
+      check(container.read(envConfigProvider).useFirebaseAuth).isA<bool>();
     });
   });
 }

--- a/test/src/core/config/app_theme_test.dart
+++ b/test/src/core/config/app_theme_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sample/src/core/config/app_theme.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,13 +11,13 @@ void main() {
 
       // Assert
       // 1. ちゃんと ThemeData 型のオブジェクトが生成されているか（内部でクラッシュしていないか）
-      expect(theme, isA<ThemeData>());
+      check(theme).isA<ThemeData>();
 
       // 2. 明るさ（Brightness）が正しく Light になっているか
-      expect(theme.brightness, equals(Brightness.light));
+      check(theme.brightness).equals(Brightness.light);
 
       // 3. Material 3 が有効になっているか（コードの意図通りか）
-      expect(theme.useMaterial3, isTrue);
+      check(theme.useMaterial3).equals(true);
     });
 
     test('dark() が正常に実行され、ダークモード用の ThemeData を返すこと', () {
@@ -25,13 +26,13 @@ void main() {
 
       // Assert
       // 1. 生成の確認
-      expect(theme, isA<ThemeData>());
+      check(theme).isA<ThemeData>();
 
       // 2. 明るさ（Brightness）が正しく Dark になっているか
-      expect(theme.brightness, equals(Brightness.dark));
+      check(theme.brightness).equals(Brightness.dark);
 
       // 3. Material 3 が有効になっているか
-      expect(theme.useMaterial3, isTrue);
+      check(theme.useMaterial3).equals(true);
     });
   });
 }

--- a/test/src/core/config/env_config_test.dart
+++ b/test/src/core/config/env_config_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -12,12 +13,12 @@ void main() {
       final config = container.read(envConfigProvider);
 
       // 環境変数が指定されていないテスト実行時、デフォルト値が返ることを確認
-      expect(config.baseUrl, defaultBaseUrl);
-      expect(config.aiModel, defaultAiModel);
-      expect(config.connectTimeout, defaultConnectTimeout);
-      expect(config.receiveTimeout, defaultReceiveTimeout);
-      expect(config.sendTimeout, defaultSendTimeout);
-      expect(config.useFirebaseAuth, defaultUseFirebaseAuth);
+      check(config.baseUrl).equals(defaultBaseUrl);
+      check(config.aiModel).equals(defaultAiModel);
+      check(config.connectTimeout).equals(defaultConnectTimeout);
+      check(config.receiveTimeout).equals(defaultReceiveTimeout);
+      check(config.sendTimeout).equals(defaultSendTimeout);
+      check(config.useFirebaseAuth).equals(defaultUseFirebaseAuth);
     });
 
     test('getDebugReport が正しいフォーマットで文字列を生成すること', () {
@@ -39,13 +40,13 @@ void main() {
 
       final report = config.getDebugReport(packageInfo);
 
-      expect(report, contains('📱 App Name          : TestApp'));
-      expect(report, contains('🆔 Package Name      : com.test.app'));
-      expect(report, contains('✨ Version           : 1.0.0 (1)'));
-      expect(report, contains('📍 API Base URL      : https://test.com'));
-      expect(report, contains('🤖 AI Model          : test-model'));
-      expect(report, contains('⏱️ Timeouts (C/R/S)  : 1 / 2 / 3'));
-      expect(report, contains('🔥 Firebase Auth     : false'));
+      check(report).contains('📱 App Name          : TestApp');
+      check(report).contains('🆔 Package Name      : com.test.app');
+      check(report).contains('✨ Version           : 1.0.0 (1)');
+      check(report).contains('📍 API Base URL      : https://test.com');
+      check(report).contains('🤖 AI Model          : test-model');
+      check(report).contains('⏱️ Timeouts (C/R/S)  : 1 / 2 / 3');
+      check(report).contains('🔥 Firebase Auth     : false');
     });
   });
 }

--- a/test/src/core/config/firebase_options_test.dart
+++ b/test/src/core/config/firebase_options_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_sample/src/core/config/firebase_options.dart';
 import 'package:flutter_sample/src/core/config/flavor_provider.dart';
@@ -15,11 +16,7 @@ void main() {
         final options = firebaseOptionsWithFlavor(flavor);
 
         // ちゃんと FirebaseOptions のインスタンスが返ってきているか（nullやエラーにならないか）を確認
-        expect(
-          options,
-          isA<FirebaseOptions>(),
-          reason: '${flavor.name} 環境の FirebaseOptions が正しく取得できませんでした',
-        );
+        check(options).isA<FirebaseOptions>();
       }
     });
   });

--- a/test/src/core/config/flavor_provider_test.dart
+++ b/test/src/core/config/flavor_provider_test.dart
@@ -1,6 +1,8 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/config/flavor_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 
 void main() {
   group('flavorProvider テスト', () {
@@ -10,8 +12,7 @@ void main() {
 
       // Assert: 上書きせずに read すると、Provider内部で UnimplementedError が発生し、
       // Riverpodの仕組みにより ProviderException としてラップされて投げられることを確認
-      expect(
-        () => container.read(flavorProvider),
+      check(() => container.read(flavorProvider)).legacyMatcher(
         throwsA(
           predicate((e) => e.toString().contains('UnimplementedError')),
         ),
@@ -31,7 +32,7 @@ void main() {
       final flavor = container.read(flavorProvider);
 
       // Assert: 上書きした値が正しく取得できること
-      expect(flavor, equals(Flavor.stg));
+      check(flavor).equals(Flavor.stg);
     });
   });
 }

--- a/test/src/core/config/flavor_provider_test.dart
+++ b/test/src/core/config/flavor_provider_test.dart
@@ -1,8 +1,8 @@
 import 'package:checks/checks.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_sample/src/core/config/flavor_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:legacy_checks/legacy_checks.dart';
 
 void main() {
   group('flavorProvider テスト', () {
@@ -12,11 +12,10 @@ void main() {
 
       // Assert: 上書きせずに read すると、Provider内部で UnimplementedError が発生し、
       // Riverpodの仕組みにより ProviderException としてラップされて投げられることを確認
-      check(() => container.read(flavorProvider)).legacyMatcher(
-        throwsA(
-          predicate((e) => e.toString().contains('UnimplementedError')),
-        ),
-      );
+      check(() => container.read(flavorProvider))
+          .throws<ProviderException>()
+          .has((e) => e.exception, 'exception')
+          .isA<UnimplementedError>();
     });
 
     test('overrideWithValue で上書きすると、その Flavor を返すこと', () {

--- a/test/src/core/config/locale_provider_test.dart
+++ b/test/src/core/config/locale_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sample/src/core/config/locale_provider.dart';
 import 'package:flutter_sample/src/core/storage/shared_preferences_provider.dart';
@@ -42,7 +43,7 @@ void main() {
       final locale = await container.read(localeProvider.future);
 
       // Assert
-      expect(locale, isNull);
+      check(locale).isNull();
       verify(() => mockPrefs.getString('locale_key')).called(1);
     });
 
@@ -58,7 +59,7 @@ void main() {
       final locale = await container.read(localeProvider.future);
 
       // Assert
-      expect(locale, equals(const Locale('ja')));
+      check(locale).equals(const Locale('ja'));
     });
 
     test('setLocale("en"): 英語に変更するとストレージに保存され、状態が更新されること', () async {
@@ -84,7 +85,7 @@ void main() {
       // Assert
       // 状態が Locale('en') に更新されていること
       final currentState = container.read(localeProvider).value;
-      expect(currentState, equals(const Locale('en')));
+      check(currentState).equals(const Locale('en'));
 
       // ストレージに保存するメソッドが正しく呼ばれたこと
       verify(() => mockPrefs.setString('locale_key', 'en')).called(1);
@@ -109,7 +110,7 @@ void main() {
       // Assert
       // 状態が null に戻っていること
       final currentState = container.read(localeProvider).value;
-      expect(currentState, isNull);
+      check(currentState).isNull();
 
       // ストレージの削除メソッドが呼ばれたこと
       verify(() => mockPrefs.remove('locale_key')).called(1);

--- a/test/src/core/config/theme_mode_provider_test.dart
+++ b/test/src/core/config/theme_mode_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sample/src/core/config/theme_mode_provider.dart';
 import 'package:flutter_sample/src/core/storage/shared_preferences_provider.dart';
@@ -41,7 +42,7 @@ void main() {
       final theme = await container.read(themeModeProvider.future);
 
       // Assert
-      expect(theme, equals(ThemeMode.system));
+      check(theme).equals(ThemeMode.system);
       verify(() => mockPrefs.getString('theme_mode')).called(1);
     });
 
@@ -59,7 +60,7 @@ void main() {
         final theme = await container.read(themeModeProvider.future);
 
         // Assert: _ThemeModeFromString.toThemeMode() が正しく動いているかの証明になります
-        expect(theme, equals(ThemeMode.dark));
+        check(theme).equals(ThemeMode.dark);
       },
     );
 
@@ -77,7 +78,7 @@ void main() {
         final theme = await container.read(themeModeProvider.future);
 
         // Assert
-        expect(theme, equals(ThemeMode.system));
+        check(theme).equals(ThemeMode.system);
       },
     );
 
@@ -99,10 +100,7 @@ void main() {
 
       // Assert
       // 1. 状態が即時反映(AsyncData)されているか
-      expect(
-        container.read(themeModeProvider).value,
-        equals(ThemeMode.light),
-      );
+      check(container.read(themeModeProvider).value).equals(ThemeMode.light);
       // 2. ThemeMode.name 経由で 'light' という文字列に変換されて保存されたか
       verify(() => mockPrefs.setString('theme_mode', 'light')).called(1);
     });
@@ -124,10 +122,7 @@ void main() {
       await notifier.toggleLightDark();
 
       // Assert
-      expect(
-        container.read(themeModeProvider).value,
-        equals(ThemeMode.dark),
-      );
+      check(container.read(themeModeProvider).value).equals(ThemeMode.dark);
       verify(() => mockPrefs.setString('theme_mode', 'dark')).called(1);
     });
 
@@ -148,10 +143,7 @@ void main() {
       await notifier.toggleLightDark();
 
       // Assert
-      expect(
-        container.read(themeModeProvider).value,
-        equals(ThemeMode.light),
-      );
+      check(container.read(themeModeProvider).value).equals(ThemeMode.light);
       verify(() => mockPrefs.setString('theme_mode', 'light')).called(1);
     });
   });

--- a/test/src/core/config/update_info_test.dart
+++ b/test/src/core/config/update_info_test.dart
@@ -1,4 +1,5 @@
 // 👇 インポートパスはご自身の環境に合わせて調整してください
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/config/update_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -20,9 +21,9 @@ void main() {
       final updateInfo = UpdateInfo.fromJson(json);
 
       // Assert
-      expect(updateInfo.requiredVersion, equals('1.2.0'));
-      expect(updateInfo.enabledAt, equals(mockDate)); // DateTime型に復元されているか
-      expect(updateInfo.canCancel, isTrue);
+      check(updateInfo.requiredVersion).equals('1.2.0');
+      check(updateInfo.enabledAt).equals(mockDate); // DateTime型に復元されているか
+      check(updateInfo.canCancel).equals(true);
     });
 
     test('fromJson() で canCancel が省略された場合、デフォルトで false になること', () {
@@ -36,9 +37,9 @@ void main() {
       final updateInfo = UpdateInfo.fromJson(json);
 
       // Assert
-      expect(updateInfo.requiredVersion, equals('1.0.0'));
+      check(updateInfo.requiredVersion).equals('1.0.0');
       // 🔥 @Default(false) が正しく機能しているかどうかの非常に重要なテスト！
-      expect(updateInfo.canCancel, isFalse);
+      check(updateInfo.canCancel).equals(false);
     });
 
     test('toJson() で正しいMap形式に変換されること', () {
@@ -52,9 +53,9 @@ void main() {
       final json = updateInfo.toJson();
 
       // Assert: キー名にタイポがないか、正しく変換されているかを確認
-      expect(json['requiredVersion'], equals('2.0.0'));
-      expect(json['enabledAt'], equals(mockDateIso));
-      expect(json['canCancel'], isFalse);
+      check(json['requiredVersion']).equals('2.0.0');
+      check(json['enabledAt']).equals(mockDateIso);
+      check(json['canCancel']).equals(false);
     });
   });
 }

--- a/test/src/core/config/update_request_provider_test.dart
+++ b/test/src/core/config/update_request_provider_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:checks/checks.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter_sample/src/core/config/flavor_provider.dart';
 import 'package:flutter_sample/src/core/config/update_request_provider.dart';
@@ -108,13 +109,13 @@ void main() {
       final container = createContainer();
       final notifier = container.read(cancelControllerProvider.notifier);
 
-      expect(container.read(cancelControllerProvider), isFalse);
+      check(container.read(cancelControllerProvider)).equals(false);
 
       notifier.clickCancel();
-      expect(container.read(cancelControllerProvider), isTrue);
+      check(container.read(cancelControllerProvider)).equals(true);
 
       notifier.reset();
-      expect(container.read(cancelControllerProvider), isFalse);
+      check(container.read(cancelControllerProvider)).equals(false);
     });
   });
 
@@ -127,7 +128,7 @@ void main() {
         updateRequestControllerProvider.future,
       );
 
-      expect(state, equals(UpdateRequestType.not));
+      check(state).equals(UpdateRequestType.not);
     });
 
     test('RemoteConfigのJSONが不正(パース失敗)な場合は例外をキャッチし not を返すこと', () async {
@@ -140,7 +141,7 @@ void main() {
         updateRequestControllerProvider.future,
       );
 
-      expect(state, equals(UpdateRequestType.not));
+      check(state).equals(UpdateRequestType.not);
     });
 
     test('現在のバージョン(1.0.0) >= 要求バージョン(1.0.0) の場合は not を返すこと', () async {
@@ -158,7 +159,7 @@ void main() {
         updateRequestControllerProvider.future,
       );
 
-      expect(state, equals(UpdateRequestType.not));
+      check(state).equals(UpdateRequestType.not);
     });
 
     test('新しいバージョン(2.0.0)だが、有効期間外(未来)の場合は not を返すこと', () async {
@@ -176,7 +177,7 @@ void main() {
         updateRequestControllerProvider.future,
       );
 
-      expect(state, equals(UpdateRequestType.not));
+      check(state).equals(UpdateRequestType.not);
     });
 
     test(
@@ -198,7 +199,7 @@ void main() {
           updateRequestControllerProvider.future,
         );
 
-        expect(state, equals(UpdateRequestType.cancelable));
+        check(state).equals(UpdateRequestType.cancelable);
       },
     );
 
@@ -221,7 +222,7 @@ void main() {
           updateRequestControllerProvider.future,
         );
 
-        expect(state, equals(UpdateRequestType.forcibly));
+        check(state).equals(UpdateRequestType.forcibly);
       },
     );
 
@@ -235,7 +236,7 @@ void main() {
         () => mockRemoteConfig.setConfigSettings(captureAny()),
       ).captured;
       final settings = captured.first as RemoteConfigSettings;
-      expect(settings.minimumFetchInterval, equals(const Duration(hours: 12)));
+      check(settings.minimumFetchInterval).equals(const Duration(hours: 12));
     });
 
     test('RemoteConfigが更新されたとき、状態がloadingを経て最新データに更新されること', () async {
@@ -276,11 +277,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       // 6. 履歴の検証
-      expect(
-        states.any((s) => s.isLoading),
-        isTrue,
-        reason: '状態遷移のどこかで一度はLoadingになっているべき',
-      );
+      check(states.any((s) => s.isLoading)).equals(true);
     });
   });
 }

--- a/test/src/core/config/update_service_test.dart
+++ b/test/src/core/config/update_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:checks/checks.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter_sample/src/core/config/update_request_provider.dart';
 import 'package:flutter_sample/src/core/config/update_service.dart';
@@ -43,7 +44,7 @@ void main() {
 
       final result = await service.getUpdateRequestType();
 
-      expect(result, UpdateRequestType.not);
+      check(result).equals(UpdateRequestType.not);
     });
 
     test('新バージョンがあり、かつ有効期限を過ぎている場合、適切な種別を返すこと', () async {
@@ -61,7 +62,7 @@ void main() {
       final service = createService();
       final result = await service.getUpdateRequestType();
 
-      expect(result, UpdateRequestType.forcibly);
+      check(result).equals(UpdateRequestType.forcibly);
     });
 
     test('新バージョンがあり、有効期限を過ぎているが、キャンセル可能な場合', () async {
@@ -78,7 +79,7 @@ void main() {
       final service = createService();
       final result = await service.getUpdateRequestType();
 
-      expect(result, UpdateRequestType.cancelable);
+      check(result).equals(UpdateRequestType.cancelable);
     });
 
     test('新バージョンがあるが、有効期限前の場合、UpdateRequestType.not を返すこと', () async {
@@ -95,7 +96,7 @@ void main() {
       final service = createService();
       final result = await service.getUpdateRequestType();
 
-      expect(result, UpdateRequestType.not);
+      check(result).equals(UpdateRequestType.not);
     });
 
     test('バージョンが同じか古い場合、UpdateRequestType.not を返すこと', () async {
@@ -112,7 +113,7 @@ void main() {
       final service = createService();
       final result = await service.getUpdateRequestType();
 
-      expect(result, UpdateRequestType.not);
+      check(result).equals(UpdateRequestType.not);
     });
 
     test('JSONのパースに失敗した場合、例外をキャッチして not を返し、警告ログを出すこと', () async {
@@ -123,7 +124,7 @@ void main() {
 
       final result = await service.getUpdateRequestType();
 
-      expect(result, UpdateRequestType.not);
+      check(result).equals(UpdateRequestType.not);
       verify(
         () => mockTalker.warning(any<String>(that: contains('Failed'))),
       ).called(1);

--- a/test/src/core/database/database_provider_test.dart
+++ b/test/src/core/database/database_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_sample/src/app/database/app_database.dart';
 import 'package:flutter_sample/src/core/database/database_provider.dart';
@@ -32,7 +33,7 @@ void main() {
       final db = container.read(appDatabaseProvider);
 
       // 生成されたインスタンスが AppDatabase であることを検証
-      expect(db, isA<AppDatabase>());
+      check(db).isA<AppDatabase>();
     });
   });
 }

--- a/test/src/core/database/drift_talker_interceptor_test.dart
+++ b/test/src/core/database/drift_talker_interceptor_test.dart
@@ -126,9 +126,9 @@ void main() {
 
       when(() => mockExecutor.runSelect(sql, args)).thenThrow(exception);
 
-      check(
+      await check(
         interceptor.runSelect(mockExecutor, sql, args),
-      ).legacyMatcher(throwsA(exception));
+      ).throws<Exception>();
 
       verify(
         () => mockTalker.error(

--- a/test/src/core/database/drift_talker_interceptor_test.dart
+++ b/test/src/core/database/drift_talker_interceptor_test.dart
@@ -1,6 +1,8 @@
+import 'package:checks/checks.dart';
 import 'package:drift/drift.dart';
 import 'package:flutter_sample/src/core/database/drift_talker_interceptor.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 
@@ -47,7 +49,7 @@ void main() {
 
       final result = await interceptor.runInsert(mockExecutor, sql, args);
 
-      expect(result, 1);
+      check(result).equals(1);
       verify(
         () => mockTalker.debug(any<String>(that: contains('[Drift] Insert'))),
       ).called(1);
@@ -62,7 +64,7 @@ void main() {
 
       final result = await interceptor.runUpdate(mockExecutor, sql, args);
 
-      expect(result, 1);
+      check(result).equals(1);
       verify(
         () => mockTalker.debug(any<String>(that: contains('[Drift] Update'))),
       ).called(1);
@@ -77,7 +79,7 @@ void main() {
 
       final result = await interceptor.runDelete(mockExecutor, sql, args);
 
-      expect(result, 1);
+      check(result).equals(1);
       verify(
         () => mockTalker.debug(any<String>(that: contains('[Drift] Delete'))),
       ).called(1);
@@ -97,7 +99,7 @@ void main() {
 
       final result = await interceptor.runSelect(mockExecutor, sql, args);
 
-      expect(result, expectedResult);
+      check(result).equals(expectedResult);
       verify(
         () => mockTalker.debug(any<String>(that: contains('[Drift] Select'))),
       ).called(1);
@@ -124,10 +126,9 @@ void main() {
 
       when(() => mockExecutor.runSelect(sql, args)).thenThrow(exception);
 
-      await expectLater(
+      check(
         interceptor.runSelect(mockExecutor, sql, args),
-        throwsA(exception),
-      );
+      ).legacyMatcher(throwsA(exception));
 
       verify(
         () => mockTalker.error(
@@ -144,10 +145,9 @@ void main() {
 
       when(() => mockExecutor.runBatched(statements)).thenThrow(exception);
 
-      await expectLater(
+      check(
         interceptor.runBatched(mockExecutor, statements),
-        throwsA(exception),
-      );
+      ).legacyMatcher(throwsA(exception));
 
       verify(
         () => mockTalker.error(

--- a/test/src/core/exceptions/app_exception_test.dart
+++ b/test/src/core/exceptions/app_exception_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/exceptions/app_exception.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -5,15 +6,15 @@ void main() {
   group('AppException テスト', () {
     test('NetworkException が正しく生成されること', () {
       const exception = AppException.network(message: 'offline');
-      expect(exception, isA<NetworkException>());
-      expect(exception.message, 'offline');
+      check(exception).isA<NetworkException>();
+      check(exception.message).equals('offline');
     });
 
     test('ServerException が正しく生成されること', () {
       const exception = AppException.server(statusCode: 500, message: 'error');
-      expect(exception, isA<ServerException>());
-      expect(exception.statusCode, 500);
-      expect(exception.message, 'error');
+      check(exception).isA<ServerException>();
+      check(exception.statusCode).equals(500);
+      check(exception.message).equals('error');
     });
 
     test('BadRequestException が正しく生成されること', () {
@@ -21,33 +22,33 @@ void main() {
         statusCode: 400,
         message: 'invalid',
       );
-      expect(exception, isA<BadRequestException>());
-      expect(exception.statusCode, 400);
-      expect(exception.message, 'invalid');
+      check(exception).isA<BadRequestException>();
+      check(exception.statusCode).equals(400);
+      check(exception.message).equals('invalid');
     });
 
     test('UnauthenticatedException が正しく生成されること', () {
       const exception = AppException.unauthenticated(message: 'not logged in');
-      expect(exception, isA<UnauthenticatedException>());
-      expect(exception.message, 'not logged in');
+      check(exception).isA<UnauthenticatedException>();
+      check(exception.message).equals('not logged in');
     });
 
     test('UnauthorizedException が正しく生成されること', () {
       const exception = AppException.unauthorized(message: 'forbidden');
-      expect(exception, isA<UnauthorizedException>());
-      expect(exception.message, 'forbidden');
+      check(exception).isA<UnauthorizedException>();
+      check(exception.message).equals('forbidden');
     });
 
     test('TimeoutException が正しく生成されること', () {
       const exception = AppException.timeout(message: 'timeout');
-      expect(exception, isA<TimeoutException>());
-      expect(exception.message, 'timeout');
+      check(exception).isA<TimeoutException>();
+      check(exception.message).equals('timeout');
     });
 
     test('DataParseException が正しく生成されること', () {
       const exception = AppException.dataParse(message: 'parse error');
-      expect(exception, isA<DataParseException>());
-      expect(exception.message, 'parse error');
+      check(exception).isA<DataParseException>();
+      check(exception.message).equals('parse error');
     });
 
     test('DatabaseException が正しく生成されること', () {
@@ -56,15 +57,15 @@ void main() {
         message: 'storage error',
         error: innerError,
       );
-      expect(exception, isA<DatabaseException>());
-      expect(exception.message, 'storage error');
-      expect(exception.error, innerError);
+      check(exception).isA<DatabaseException>();
+      check(exception.message).equals('storage error');
+      check(exception.error).equals(innerError);
     });
 
     test('CancelException が正しく生成されること', () {
       const exception = AppException.cancel(message: 'canceled');
-      expect(exception, isA<CancelException>());
-      expect(exception.message, 'canceled');
+      check(exception).isA<CancelException>();
+      check(exception.message).equals('canceled');
     });
 
     test('UnknownException が正しく生成されること', () {
@@ -73,9 +74,9 @@ void main() {
         message: 'unknown',
         error: innerError,
       );
-      expect(exception, isA<UnknownException>());
-      expect(exception.message, 'unknown');
-      expect(exception.error, innerError);
+      check(exception).isA<UnknownException>();
+      check(exception.message).equals('unknown');
+      check(exception.error).equals(innerError);
     });
 
     test('pattern matching (switch expression) が正しく動作すること', () {
@@ -92,7 +93,7 @@ void main() {
         CancelException() => 'cancel',
         UnknownException() => 'unknown',
       };
-      expect(result, 'timeout');
+      check(result).equals('timeout');
     });
   });
 }

--- a/test/src/core/network/api_client_test.dart
+++ b/test/src/core/network/api_client_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_sample/src/core/network/api_client.dart';
@@ -66,7 +67,7 @@ void main() {
       );
 
       // Assert
-      expect(result.data, equals({'success': true}));
+      check(result.data).isNotNull().deepEquals({'success': true});
       verify(
         () => mockDio.get<Map<String, dynamic>>(
           path,
@@ -182,20 +183,20 @@ void main() {
 
       final dio = testContainer.read(dioProvider);
 
-      expect(dio.options.baseUrl, isNotEmpty);
-      expect(dio.options.connectTimeout, isNotNull);
-      expect(dio.options.receiveTimeout, isNotNull);
-      expect(dio.options.sendTimeout, isNotNull);
-      expect(dio.options.headers['Content-Type'], equals('application/json'));
+      check(dio.options.baseUrl).isNotEmpty();
+      check(dio.options.connectTimeout).isNotNull();
+      check(dio.options.receiveTimeout).isNotNull();
+      check(dio.options.sendTimeout).isNotNull();
+      check(dio.options.headers['Content-Type']).equals('application/json');
 
       // runtimeType を使って、期待するインターセプターが含まれているか確認
       final interceptorTypes = dio.interceptors
           .map((i) => i.runtimeType)
           .toList();
 
-      expect(interceptorTypes[1], equals(MockTokenInterceptor));
-      expect(interceptorTypes[2], equals(MockDioInterceptor));
-      expect(interceptorTypes[3], equals(TalkerDioLogger));
+      check(interceptorTypes[1]).equals(MockTokenInterceptor);
+      check(interceptorTypes[2]).equals(MockDioInterceptor);
+      check(interceptorTypes[3]).equals(TalkerDioLogger);
 
       testContainer.dispose();
     });

--- a/test/src/core/network/dio_interceptor_test.dart
+++ b/test/src/core/network/dio_interceptor_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_sample/src/core/exceptions/app_exception.dart';
 import 'package:flutter_sample/src/core/network/dio_interceptor.dart';
@@ -68,7 +69,7 @@ void main() {
       final captured =
           verify(() => handler.reject(captureAny())).captured.first
               as DioException;
-      expect(captured.error, isA<TimeoutException>());
+      check(captured.error).isA<TimeoutException>();
     });
 
     test(
@@ -93,9 +94,9 @@ void main() {
         final captured =
             verify(() => handler.reject(captureAny())).captured.first
                 as DioException;
-        expect(captured.error, isA<BadRequestException>());
+        check(captured.error).isA<BadRequestException>();
         final appEx = captured.error! as AppException;
-        expect(appEx.statusCode, equals(404));
+        check(appEx.statusCode).equals(404);
       },
     );
 
@@ -119,7 +120,7 @@ void main() {
       final captured =
           verify(() => handler.reject(captureAny())).captured.first
               as DioException;
-      expect(captured.error, isA<UnauthenticatedException>());
+      check(captured.error).isA<UnauthenticatedException>();
     });
 
     test('onError: badResponse(500) が ServerException に変換されること', () {
@@ -142,7 +143,7 @@ void main() {
       final captured =
           verify(() => handler.reject(captureAny())).captured.first
               as DioException;
-      expect(captured.error, isA<ServerException>());
+      check(captured.error).isA<ServerException>();
     });
 
     test('onError: badResponse 且つ statusCode が null の場合は '
@@ -165,7 +166,7 @@ void main() {
       final captured =
           verify(() => handler.reject(captureAny())).captured.first
               as DioException;
-      expect(captured.error, isA<UnknownException>());
+      check(captured.error).isA<UnknownException>();
     });
 
     test('onError: 未定義の statusCode の場合は UnknownException になること', () {
@@ -188,7 +189,7 @@ void main() {
       final captured =
           verify(() => handler.reject(captureAny())).captured.first
               as DioException;
-      expect(captured.error, isA<UnknownException>());
+      check(captured.error).isA<UnknownException>();
     });
 
     test('onError: unknownエラーが UnknownException に変換されること', () {
@@ -207,11 +208,10 @@ void main() {
       final captured =
           verify(() => handler.reject(captureAny())).captured.first
               as DioException;
-      expect(captured.error, isA<UnknownException>());
-      expect(
+      check(captured.error).isA<UnknownException>();
+      check(
         (captured.error! as AppException).whenOrNull(unknown: (msg, _) => msg),
-        contains('unknown error'),
-      );
+      ).isNotNull().contains('unknown error');
     });
 
     test('onRequest/onResponse: ログが出力され、handler.next が呼ばれること', () {

--- a/test/src/core/network/dio_interceptor_test.dart
+++ b/test/src/core/network/dio_interceptor_test.dart
@@ -208,10 +208,11 @@ void main() {
       final captured =
           verify(() => handler.reject(captureAny())).captured.first
               as DioException;
-      check(captured.error).isA<UnknownException>();
-      check(
-        (captured.error! as AppException).whenOrNull(unknown: (msg, _) => msg),
-      ).isNotNull().contains('unknown error');
+      check(captured.error)
+          .isA<UnknownException>()
+          .has((e) => e.message, 'message')
+          .isNotNull()
+          .contains('unknown error');
     });
 
     test('onRequest/onResponse: ログが出力され、handler.next が呼ばれること', () {

--- a/test/src/core/network/dio_provider_test.dart
+++ b/test/src/core/network/dio_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_sample/src/core/network/dio_interceptor.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_sample/src/core/network/token_interceptor.dart';
 import 'package:flutter_sample/src/core/utils/logger_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:talker_dio_logger/talker_dio_logger.dart';
 import 'package:talker_flutter/talker_flutter.dart';
@@ -60,20 +62,20 @@ void main() {
       final dio = container.read(dioProvider);
 
       // 基本設定の検証
-      expect(dio.options.baseUrl, equals(config.baseUrl));
-      expect(dio.options.connectTimeout, equals(const Duration(seconds: 5)));
-      expect(dio.options.receiveTimeout, equals(const Duration(seconds: 10)));
-      expect(dio.options.sendTimeout, equals(const Duration(seconds: 5)));
-      expect(dio.options.headers['Content-Type'], equals('application/json'));
+      check(dio.options.baseUrl).equals(config.baseUrl);
+      check(dio.options.connectTimeout).equals(const Duration(seconds: 5));
+      check(dio.options.receiveTimeout).equals(const Duration(seconds: 10));
+      check(dio.options.sendTimeout).equals(const Duration(seconds: 5));
+      check(dio.options.headers['Content-Type']).equals('application/json');
 
       // インターセプターの検証
       final interceptorTypes = dio.interceptors
           .map((i) => i.runtimeType)
           .toList();
 
-      expect(interceptorTypes, contains(mockTokenInterceptor.runtimeType));
-      expect(interceptorTypes, contains(mockDioInterceptor.runtimeType));
-      expect(interceptorTypes, contains(TalkerDioLogger));
+      check(interceptorTypes).contains(mockTokenInterceptor.runtimeType);
+      check(interceptorTypes).contains(mockDioInterceptor.runtimeType);
+      check(interceptorTypes).contains(TalkerDioLogger);
     });
   });
 
@@ -92,8 +94,8 @@ void main() {
       final dio = container.read(baseDioProvider);
 
       // 基本設定の検証
-      expect(dio.options.baseUrl, equals(config.baseUrl));
-      expect(dio.options.connectTimeout, equals(const Duration(seconds: 3)));
+      check(dio.options.baseUrl).equals(config.baseUrl);
+      check(dio.options.connectTimeout).equals(const Duration(seconds: 3));
 
       // インターセプターの検証
       final interceptorTypes = dio.interceptors
@@ -101,13 +103,12 @@ void main() {
           .toList();
 
       // トークンインターセプターが含まれていないこと
-      expect(
+      check(
         interceptorTypes,
-        isNot(contains(mockTokenInterceptor.runtimeType)),
-      );
+      ).legacyMatcher(isNot(contains(mockTokenInterceptor.runtimeType)));
       // 共通インターセプターとロガーは含まれていること
-      expect(interceptorTypes, contains(mockDioInterceptor.runtimeType));
-      expect(interceptorTypes, contains(TalkerDioLogger));
+      check(interceptorTypes).contains(mockDioInterceptor.runtimeType);
+      check(interceptorTypes).contains(TalkerDioLogger);
     });
   });
 }

--- a/test/src/core/network/token_interceptor_test.dart
+++ b/test/src/core/network/token_interceptor_test.dart
@@ -1,11 +1,13 @@
 // ignore_for_file: one_member_abstracts, document_ignores
 
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_sample/src/core/network/dio_provider.dart';
 import 'package:flutter_sample/src/core/network/token_interceptor.dart';
 import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 
 // --- モッククラス群 ---
@@ -79,7 +81,7 @@ void main() {
       // 内部で await されるため、dynamic で受けて await する
       await (interceptor as dynamic).onRequest(options, handler);
 
-      expect(options.headers['Authorization'], equals('Bearer valid_token'));
+      check(options.headers['Authorization']).equals('Bearer valid_token');
       verify(() => handler.next(options)).called(1);
     });
 
@@ -111,7 +113,7 @@ void main() {
 
       await (interceptor as dynamic).onError(error401, handler);
 
-      expect(options.headers['Authorization'], equals('Bearer new_token'));
+      check(options.headers['Authorization']).equals('Bearer new_token');
       verify(() => handler.resolve(mockResponse)).called(1);
     });
 
@@ -196,7 +198,7 @@ void main() {
 
     await (interceptor as dynamic).onRequest(options, handler);
 
-    expect(options.headers.containsKey('Authorization'), isFalse);
+    check(options.headers.containsKey('Authorization')).equals(false);
     verify(() => handler.next(options)).called(1);
   });
 
@@ -250,8 +252,9 @@ void main() {
 
       // Riverpodは内部のエラーを ProviderException で包んで投げる仕様があるため、
       // エラーの文字列表現 (toString) の中に目的のメッセージが含まれているかを検証します。
-      expect(
+      check(
         () => emptyContainer.read(tokenRefreshCallbackProvider),
+      ).legacyMatcher(
         throwsA(
           predicate(
             (e) => e.toString().contains(

--- a/test/src/core/storage/cache_manager_test.dart
+++ b/test/src/core/storage/cache_manager_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/storage/cache_manager.dart';
 import 'package:flutter_sample/src/core/storage/shared_preferences_provider.dart';
 import 'package:flutter_sample/src/core/utils/date_time_provider.dart';
@@ -69,8 +70,8 @@ void main() {
       final (data, ts) = await manager.getWithTimestamp(testKey);
 
       // Assert
-      expect(data, testValue);
-      expect(ts, DateTime.fromMillisecondsSinceEpoch(tsMs));
+      check(data as Map).deepEquals(testValue);
+      check(ts).equals(DateTime.fromMillisecondsSinceEpoch(tsMs));
     });
 
     test('get: ショートカットメソッドでデータのみ取得できること', () async {
@@ -89,7 +90,7 @@ void main() {
       final result = await manager.get(testKey);
 
       // Assert
-      expect(result, testValue);
+      check(result as Map).deepEquals(testValue);
     });
 
     test('getWithTimestamp: 期限切れのキャッシュは削除して (null, null) を返すこと', () async {
@@ -110,8 +111,8 @@ void main() {
       final (data, ts) = await manager.getWithTimestamp(testKey);
 
       // Assert
-      expect(data, isNull);
-      expect(ts, isNull);
+      check(data).isNull();
+      check(ts).isNull();
       verify(() => mockPrefs.remove(testKey)).called(1);
     });
 
@@ -124,8 +125,8 @@ void main() {
       final (data, ts) = await manager.getWithTimestamp(testKey);
 
       // Assert
-      expect(data, isNull);
-      expect(ts, isNull);
+      check(data).isNull();
+      check(ts).isNull();
     });
 
     test(
@@ -142,8 +143,8 @@ void main() {
         final (data, ts) = await manager.getWithTimestamp(testKey);
 
         // Assert
-        expect(data, isNull);
-        expect(ts, isNull);
+        check(data).isNull();
+        check(ts).isNull();
         verify(() => mockPrefs.remove(testKey)).called(1);
       },
     );

--- a/test/src/core/storage/cache_manager_test.dart
+++ b/test/src/core/storage/cache_manager_test.dart
@@ -70,7 +70,7 @@ void main() {
       final (data, ts) = await manager.getWithTimestamp(testKey);
 
       // Assert
-      check(data as Map).deepEquals(testValue);
+      check(data).isA<Map<dynamic, dynamic>>().deepEquals(testValue);
       check(ts).equals(DateTime.fromMillisecondsSinceEpoch(tsMs));
     });
 

--- a/test/src/core/storage/token_storage_test.dart
+++ b/test/src/core/storage/token_storage_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/storage/secure_storage_provider.dart';
 import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -67,7 +68,7 @@ void main() {
       final result = await storage.getAccessToken();
 
       // Assert
-      expect(result, testAccessToken);
+      check(result).equals(testAccessToken);
       verify(() => mockStorage.read(key: accessTokenKey)).called(1);
     });
 
@@ -82,7 +83,7 @@ void main() {
       final result = await storage.getRefreshToken();
 
       // Assert
-      expect(result, testRefreshToken);
+      check(result).equals(testRefreshToken);
       verify(() => mockStorage.read(key: refreshTokenKey)).called(1);
     });
 
@@ -113,8 +114,8 @@ void main() {
       final refresh = await storage.getRefreshToken();
 
       // Assert
-      expect(access, isNull);
-      expect(refresh, isNull);
+      check(access).isNull();
+      check(refresh).isNull();
     });
   });
 
@@ -132,7 +133,7 @@ void main() {
       final token = await storage.getAccessToken();
 
       // Assert
-      expect(token, 'raw_token');
+      check(token).equals('raw_token');
       verify(() => mockStorage.read(key: 'access_token')).called(1);
     });
   });

--- a/test/src/core/ui/error_handler_test.dart
+++ b/test/src/core/ui/error_handler_test.dart
@@ -1,6 +1,8 @@
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/exceptions/app_exception.dart';
 import 'package:flutter_sample/src/core/exceptions/firebase_auth_error_codes.dart';
@@ -96,7 +98,7 @@ void main() {
           );
         },
       );
-      expect(result, 'UNIQUE_CUSTOM_MSG');
+      check(result).equals('UNIQUE_CUSTOM_MSG');
     });
 
     testWidgets('2. AppException (Network/Server/Timeout/Unknown) の分岐が正しいこと', (
@@ -106,52 +108,42 @@ void main() {
         tester,
         onBuild: (context) {
           // それぞれの Enum (型) に応じて正しい多言語化キーが返るか検証
-          expect(
+          check(
             ErrorHandler.message(context, const AppException.network()),
-            'errorNetwork',
-          );
-          expect(
+          ).equals('errorNetwork');
+          check(
             ErrorHandler.message(
               context,
               const AppException.server(statusCode: 500),
             ),
-            'errorServer (500)',
-          );
-          expect(
+          ).equals('errorServer (500)');
+          check(
             ErrorHandler.message(context, const AppException.unauthenticated()),
-            'errorUnauthenticated',
-          );
-          expect(
+          ).equals('errorUnauthenticated');
+          check(
             ErrorHandler.message(context, const AppException.unauthorized()),
-            'errorUnauthorized',
-          );
-          expect(
+          ).equals('errorUnauthorized');
+          check(
             ErrorHandler.message(context, const AppException.dataParse()),
-            'errorDataParse',
-          );
-          expect(
+          ).equals('errorDataParse');
+          check(
             ErrorHandler.message(context, const AppException.database()),
-            'errorDatabase',
-          );
-          expect(
+          ).equals('errorDatabase');
+          check(
             ErrorHandler.message(
               context,
               const AppException.badRequest(statusCode: 400),
             ),
-            'errorBadRequest (400)',
-          );
-          expect(
+          ).equals('errorBadRequest (400)');
+          check(
             ErrorHandler.message(context, const AppException.timeout()),
-            'errorTimeout',
-          );
-          expect(
+          ).equals('errorTimeout');
+          check(
             ErrorHandler.message(context, const AppException.cancel()),
-            'errorUnknown',
-          );
-          expect(
+          ).equals('errorUnknown');
+          check(
             ErrorHandler.message(context, const AppException.unknown()),
-            'errorUnknown',
-          );
+          ).equals('errorUnknown');
         },
       );
     });
@@ -160,13 +152,12 @@ void main() {
       await setupWidget(
         tester,
         onBuild: (context) {
-          expect(
+          check(
             ErrorHandler.message(
               context,
               const AppException.network(message: 'CUSTOM_NETWORK'),
             ),
-            'CUSTOM_NETWORK',
-          );
+          ).equals('CUSTOM_NETWORK');
         },
       );
     });
@@ -187,60 +178,54 @@ void main() {
         },
       );
       // TimeoutException として処理されていることを確認
-      expect(result, 'errorTimeout');
+      check(result).equals('errorTimeout');
     });
 
     testWidgets('4. FirebaseAuthException の各エラーコードが正しく変換されること', (tester) async {
       await setupWidget(
         tester,
         onBuild: (context) {
-          expect(
+          check(
             ErrorHandler.message(
               context,
               FirebaseAuthException(code: FirebaseAuthErrorCodes.invalidEmail),
             ),
-            'errorInvalidEmail',
-          );
-          expect(
+          ).equals('errorInvalidEmail');
+          check(
             ErrorHandler.message(
               context,
               FirebaseAuthException(code: FirebaseAuthErrorCodes.userDisabled),
             ),
-            'errorUserDisabled',
-          );
-          expect(
+          ).equals('errorUserDisabled');
+          check(
             ErrorHandler.message(
               context,
               FirebaseAuthException(code: FirebaseAuthErrorCodes.wrongPassword),
             ),
-            'errorLoginFailed',
-          );
-          expect(
+          ).equals('errorLoginFailed');
+          check(
             ErrorHandler.message(
               context,
               FirebaseAuthException(
                 code: FirebaseAuthErrorCodes.emailAlreadyInUse,
               ),
             ),
-            'errorEmailAlreadyInUse',
-          );
-          expect(
+          ).equals('errorEmailAlreadyInUse');
+          check(
             ErrorHandler.message(
               context,
               FirebaseAuthException(code: FirebaseAuthErrorCodes.weakPassword),
             ),
-            'errorWeakPassword',
-          );
+          ).equals('errorWeakPassword');
           // 未定義のコードは errorUnknown にフォールバックすること
-          expect(
+          check(
             ErrorHandler.message(
               context,
               FirebaseAuthException(
                 code: 'some-unknown-code',
               ),
             ),
-            'errorUnknown',
-          );
+          ).equals('errorUnknown');
         },
       );
     });
@@ -255,7 +240,7 @@ void main() {
           result = ErrorHandler.message(context, Exception('General Error'));
         },
       );
-      expect(result, 'errorUnknown');
+      check(result).equals('errorUnknown');
     });
   });
 
@@ -277,7 +262,7 @@ void main() {
       await tester.tap(find.text('Show'));
       await tester.pump();
 
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
     });
 
     testWidgets('showDialogError が正常に表示され、OKで閉じられること', (tester) async {
@@ -297,12 +282,12 @@ void main() {
       await tester.tap(find.text('Show'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
 
       await tester.tap(find.text('ok'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsNothing);
+      check(find.byType(AlertDialog)).findsNothing();
     });
   });
 }

--- a/test/src/core/ui/l10n_extension_test.dart
+++ b/test/src/core/ui/l10n_extension_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/ui/l10n_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,7 +22,7 @@ void main() {
         ),
       );
 
-      expect(find.text('OK'), findsOneWidget);
+      check(find.text('OK')).findsOne();
     });
 
     testWidgets('l10n throws FlutterError when AppLocalizations is not found', (
@@ -37,11 +39,10 @@ void main() {
       );
 
       final dynamic exception = tester.takeException();
-      expect(exception, isA<FlutterError>());
-      expect(
+      check(exception).isA<FlutterError>();
+      check(
         exception.toString(),
-        contains('AppLocalizations not found in the current context'),
-      );
+      ).contains('AppLocalizations not found in the current context');
     });
   });
 }

--- a/test/src/core/ui/snackbar_extension_test.dart
+++ b/test/src/core/ui/snackbar_extension_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/ui/snackbar_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -40,24 +42,23 @@ void main() {
     await tester.pumpAndSettle(); // Wait for animation to finish
 
     // Verify SnackBar appears
-    expect(find.byType(SnackBar), findsOneWidget);
-    expect(find.text(testMessage), findsOneWidget);
-    expect(find.byIcon(Icons.info_outline), findsOneWidget);
-    expect(
-      find.text('Close'),
-      findsOneWidget,
-    ); // Close text from AppLocalizations
+    check(find.byType(SnackBar)).findsOne();
+    check(find.text(testMessage)).findsOne();
+    check(find.byIcon(Icons.info_outline)).findsOne();
+    check(find.text('Close')).findsOne(); // Close text from AppLocalizations
 
     // Verify background color
     final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-    expect(snackBar.backgroundColor, theme.colorScheme.secondaryContainer);
+    check(
+      snackBar.backgroundColor,
+    ).equals(theme.colorScheme.secondaryContainer);
 
     // Tap 'Close' action to dismiss
     await tester.tap(find.text('Close'));
     await tester.pumpAndSettle();
 
     // Verify SnackBar is dismissed
-    expect(find.byType(SnackBar), findsNothing);
+    check(find.byType(SnackBar)).findsNothing();
   });
 
   testWidgets('showSuccessSnackBar displays a success SnackBar', (
@@ -75,12 +76,12 @@ void main() {
     await tester.pump();
 
     // Verify success specific elements
-    expect(find.byType(SnackBar), findsOneWidget);
-    expect(find.text(testMessage), findsOneWidget);
-    expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+    check(find.byType(SnackBar)).findsOne();
+    check(find.text(testMessage)).findsOne();
+    check(find.byIcon(Icons.check_circle_outline)).findsOne();
 
     final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-    expect(snackBar.backgroundColor, theme.colorScheme.primaryContainer);
+    check(snackBar.backgroundColor).equals(theme.colorScheme.primaryContainer);
   });
 
   testWidgets('showErrorSnackBar displays an error SnackBar', (
@@ -98,12 +99,12 @@ void main() {
     await tester.pump();
 
     // Verify error specific elements
-    expect(find.byType(SnackBar), findsOneWidget);
-    expect(find.text(testMessage), findsOneWidget);
-    expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    check(find.byType(SnackBar)).findsOne();
+    check(find.text(testMessage)).findsOne();
+    check(find.byIcon(Icons.error_outline)).findsOne();
 
     final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-    expect(snackBar.backgroundColor, theme.colorScheme.errorContainer);
+    check(snackBar.backgroundColor).equals(theme.colorScheme.errorContainer);
   });
 
   testWidgets(
@@ -143,7 +144,7 @@ void main() {
       // Tap first button
       await tester.tap(find.byKey(const Key('btn1')));
       await tester.pump();
-      expect(find.text(message1), findsOneWidget);
+      check(find.text(message1)).findsOne();
 
       // Tap second button immediately
       await tester.tap(find.byKey(const Key('btn2')));
@@ -154,8 +155,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // First message should be removed, second should be visible
-      expect(find.text(message1), findsNothing);
-      expect(find.text(message2), findsOneWidget);
+      check(find.text(message1)).findsNothing();
+      check(find.text(message2)).findsOne();
     },
   );
 }

--- a/test/src/core/utils/app_lifecycle_provider_test.dart
+++ b/test/src/core/utils/app_lifecycle_provider_test.dart
@@ -1,7 +1,9 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_sample/src/core/utils/app_lifecycle_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 
 void main() {
   // 【重要】WidgetsBinding（Flutterのコア機能）を使うテストでは、
@@ -26,7 +28,7 @@ void main() {
       final initialState = subscription.read();
 
       // テスト環境起動時はデフォルトで resumed になる仕様です
-      expect(initialState, AppLifecycleState.resumed);
+      check(initialState).equals(AppLifecycleState.resumed);
     });
 
     test('システムのライフサイクルが変化した時、プロバイダーのStateが正しく更新されること', () {
@@ -39,21 +41,21 @@ void main() {
       );
 
       // 状態が paused に更新されていることを確認
-      expect(subscription.read(), AppLifecycleState.paused);
+      check(subscription.read()).equals(AppLifecycleState.paused);
 
       // 2. アプリが非アクティブ（inactive: スワイプでタスク一覧を出している時など）をシミュレート
       WidgetsBinding.instance.handleAppLifecycleStateChanged(
         AppLifecycleState.inactive,
       );
 
-      expect(subscription.read(), AppLifecycleState.inactive);
+      check(subscription.read()).equals(AppLifecycleState.inactive);
 
       // 3. アプリが再びフォアグラウンドに戻ってきた（resumed）状態をシミュレート
       WidgetsBinding.instance.handleAppLifecycleStateChanged(
         AppLifecycleState.resumed,
       );
 
-      expect(subscription.read(), AppLifecycleState.resumed);
+      check(subscription.read()).equals(AppLifecycleState.resumed);
     });
 
     test('プロバイダーが破棄(dispose)された時、エラーが発生しないこと', () {
@@ -69,12 +71,11 @@ void main() {
         ..dispose();
 
       // 破棄後にライフサイクルが変わってもエラー（メモリリーク等）が起きないことを確認
-      expect(
+      check(
         () => WidgetsBinding.instance.handleAppLifecycleStateChanged(
           AppLifecycleState.paused,
         ),
-        returnsNormally,
-      );
+      ).legacyMatcher(returnsNormally);
     });
   });
 }

--- a/test/src/core/utils/connectivity_provider_test.dart
+++ b/test/src/core/utils/connectivity_provider_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async'; // StreamControllerを使うために追加
 
+import 'package:checks/checks.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_sample/src/core/utils/connectivity_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -30,7 +31,7 @@ void main() {
       final subscription = container.listen(isOnlineProvider, (_, _) {});
 
       // 監視員経由で現在の値を読み取る
-      expect(subscription.read(), isTrue);
+      check(subscription.read()).equals(true);
     });
 
     test('接続状態が「none（未接続）」の場合は、falseを返すこと', () async {
@@ -49,7 +50,7 @@ void main() {
       await container.read(connectivityProvider.future);
 
       // 監視員経由で値を確認
-      expect(subscription.read(), isFalse);
+      check(subscription.read()).equals(false);
     });
 
     test('接続状態に「none」が含まれていない（Wi-Fi等に接続中）場合は、trueを返すこと', () async {
@@ -67,7 +68,7 @@ void main() {
       // 値が流れてくるのを待つ
       await container.read(connectivityProvider.future);
 
-      expect(subscription.read(), isTrue);
+      check(subscription.read()).equals(true);
     });
 
     test('複数の接続状態があり、「none」が含まれていない場合は、trueを返すこと', () async {
@@ -88,7 +89,7 @@ void main() {
       // 値が流れてくるのを待つ
       await container.read(connectivityProvider.future);
 
-      expect(subscription.read(), isTrue);
+      check(subscription.read()).equals(true);
     });
   });
 }

--- a/test/src/core/utils/date_time_provider_test.dart
+++ b/test/src/core/utils/date_time_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/utils/date_time_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -13,10 +14,7 @@ void main() {
       final clockNow = clock();
 
       // 数ミリ秒の誤差は許容する
-      expect(
-        clockNow.difference(now).inMilliseconds.abs(),
-        lessThan(100),
-      );
+      check(clockNow.difference(now).inMilliseconds.abs()).isLessThan(100);
     });
 
     test('clockProvider を関数のモックで上書きできること', () {
@@ -30,7 +28,7 @@ void main() {
       addTearDown(container.dispose);
 
       final clock = container.read(clockProvider);
-      expect(clock(), mockDate);
+      check(clock()).equals(mockDate);
     });
   });
 }

--- a/test/src/core/utils/logger_provider_test.dart
+++ b/test/src/core/utils/logger_provider_test.dart
@@ -1,6 +1,8 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/utils/logger_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 
@@ -31,8 +33,7 @@ void main() {
         final container = ProviderContainer();
         addTearDown(container.dispose);
 
-        expect(
-          () => container.read(loggerProvider),
+        check(() => container.read(loggerProvider)).legacyMatcher(
           throwsA(
             predicate((e) => e.toString().contains('UnimplementedError')),
           ),
@@ -50,7 +51,7 @@ void main() {
       addTearDown(container.dispose);
 
       final logger = container.read(loggerProvider);
-      expect(logger, equals(mockTalker));
+      check(logger).equals(mockTalker);
     });
   });
 

--- a/test/src/core/utils/package_info_provider_test.dart
+++ b/test/src/core/utils/package_info_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_sample/src/core/utils/package_info_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,10 +12,9 @@ void main() {
       addTearDown(container.dispose);
 
       // 💡 修正: Riverpodは内部エラーをProviderExceptionで包んで投げる仕様なので、それを検知する
-      expect(
+      check(
         () => container.read(packageInfoProvider),
-        throwsA(isA<ProviderException>()),
-      );
+      ).throws<ProviderException>();
     });
 
     test('【正常系】オーバーライドしたPackageInfoのモックデータが正しく取得できること', () {
@@ -34,11 +34,11 @@ void main() {
 
       final result = container.read(packageInfoProvider);
 
-      expect(result, equals(mockPackageInfo));
-      expect(result.appName, 'Test App');
-      expect(result.packageName, 'com.example.test_app');
-      expect(result.version, '1.0.0');
-      expect(result.buildNumber, '100');
+      check(result).equals(mockPackageInfo);
+      check(result.appName).equals('Test App');
+      check(result.packageName).equals('com.example.test_app');
+      check(result.version).equals('1.0.0');
+      check(result.buildNumber).equals('100');
     });
   });
 }

--- a/test/src/core/widgets/not_found_screen_test.dart
+++ b/test/src/core/widgets/not_found_screen_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/widgets/not_found_screen.dart';
@@ -62,20 +64,20 @@ void main() {
     testWidgets('unknownPathがなくても正しく描画される', (tester) async {
       await pumpWidget(tester);
 
-      expect(find.text('Page Not Found'), findsNWidgets(2));
-      expect(find.text('The page could not be found.'), findsOneWidget);
-      expect(find.text('Back to Home'), findsOneWidget);
-      expect(find.byIcon(Icons.search_off_outlined), findsOneWidget);
+      check(find.text('Page Not Found')).findsExactly(2);
+      check(find.text('The page could not be found.')).findsOne();
+      check(find.text('Back to Home')).findsOne();
+      check(find.byIcon(Icons.search_off_outlined)).findsOne();
     });
 
     testWidgets('unknownPathがあっても正しく描画される', (tester) async {
       const path = '/test_path';
       await pumpWidget(tester, unknownPath: path);
 
-      expect(find.text('Page Not Found'), findsNWidgets(2));
-      expect(find.text('The page could not be found.'), findsOneWidget);
-      expect(find.text('path: $path'), findsOneWidget);
-      expect(find.text('Back to Home'), findsOneWidget);
+      check(find.text('Page Not Found')).findsExactly(2);
+      check(find.text('The page could not be found.')).findsOne();
+      check(find.text('path: $path')).findsOne();
+      check(find.text('Back to Home')).findsOne();
     });
 
     testWidgets('ボタンをタップするとホーム画面に遷移する', (tester) async {

--- a/test/src/core/widgets/version_up_dialog_test.dart
+++ b/test/src/core/widgets/version_up_dialog_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/widgets/version_up_dialog.dart';
@@ -58,24 +60,24 @@ void main() {
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsOneWidget);
-      expect(find.text('A new version is available.'), findsOneWidget);
-      expect(find.widgetWithText(TextButton, 'Later'), findsOneWidget);
-      expect(find.widgetWithText(TextButton, 'Update'), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
+      check(find.text('A new version is available.')).findsOne();
+      check(find.widgetWithText(TextButton, 'Later')).findsOne();
+      check(find.widgetWithText(TextButton, 'Update')).findsOne();
 
       // アップデートボタン
       await tester.tap(find.widgetWithText(TextButton, 'Update'));
       await tester.pumpAndSettle();
-      expect(onUpdateCalled, isTrue);
-      expect(find.byType(AlertDialog), findsNothing);
+      check(onUpdateCalled).equals(true);
+      check(find.byType(AlertDialog)).findsNothing();
 
       // 再表示してキャンセルボタン
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(TextButton, 'Later'));
       await tester.pumpAndSettle();
-      expect(onCancelCalled, isTrue);
-      expect(find.byType(AlertDialog), findsNothing);
+      check(onCancelCalled).equals(true);
+      check(find.byType(AlertDialog)).findsNothing();
     });
 
     testWidgets('強制アップデートダイアログが表示され、キャンセル不可であること', (tester) async {
@@ -96,20 +98,20 @@ void main() {
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsOneWidget);
-      expect(find.text('A new version is required.'), findsOneWidget);
-      expect(find.widgetWithText(TextButton, 'Later'), findsNothing);
+      check(find.byType(AlertDialog)).findsOne();
+      check(find.text('A new version is required.')).findsOne();
+      check(find.widgetWithText(TextButton, 'Later')).findsNothing();
 
       // ダイアログ外タップで閉じないこと
       await tester.tapAt(Offset.zero);
       await tester.pumpAndSettle();
-      expect(find.byType(AlertDialog), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
 
       // アップデート
       await tester.tap(find.widgetWithText(TextButton, 'Update'));
       await tester.pumpAndSettle();
-      expect(onUpdateCalled, isTrue);
-      expect(find.byType(AlertDialog), findsNothing);
+      check(onUpdateCalled).equals(true);
+      check(find.byType(AlertDialog)).findsNothing();
     });
 
     testWidgets('キャンセル可能な場合にダイアログ外をタップするとキャンセル扱いになること', (tester) async {
@@ -133,8 +135,8 @@ void main() {
       await tester.tapAt(Offset.zero);
       await tester.pumpAndSettle();
 
-      expect(onCancelCalled, isTrue);
-      expect(find.byType(AlertDialog), findsNothing);
+      check(onCancelCalled).equals(true);
+      check(find.byType(AlertDialog)).findsNothing();
     });
   });
 }

--- a/test/src/features/auth/application/auth_state_notifier_test.dart
+++ b/test/src/features/auth/application/auth_state_notifier_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_sample/src/features/auth/application/auth_state_notifier.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -65,7 +66,7 @@ void main() {
       final authState = await container.read(authStateProvider.future);
 
       // Assert
-      expect(authState, isTrue);
+      check(authState).equals(true);
     });
 
     test('初期化: トークンがない場合、state が false になること', () async {
@@ -77,7 +78,7 @@ void main() {
       final authState = await container.read(authStateProvider.future);
 
       // Assert
-      expect(authState, isFalse);
+      check(authState).equals(false);
     });
   });
 
@@ -92,11 +93,10 @@ void main() {
       await notifier.login('access', 'refresh');
 
       // Assert
-      expect(fakeStorage.isSaveTokensCalled, isTrue); // saveTokens が呼ばれたか
-      expect(
+      check(fakeStorage.isSaveTokensCalled).equals(true); // saveTokens が呼ばれたか
+      check(
         container.read(authStateProvider).value,
-        isTrue,
-      ); // state が true か
+      ).equals(true); // state が true か
     });
 
     test('login: トークンの保存に失敗した場合、例外がスローされ state が AsyncError になること', () async {
@@ -106,17 +106,13 @@ void main() {
       final notifier = container.read(authStateProvider.notifier);
 
       // Act & Assert
-      await expectLater(
-        () => notifier.login('access', 'refresh'),
-        throwsException,
-      );
+      await check(notifier.login('access', 'refresh')).throws<Exception>();
 
       // Assert
-      expect(fakeStorage.isSaveTokensCalled, isTrue); // saveTokens が呼ばれたか
-      expect(
+      check(fakeStorage.isSaveTokensCalled).equals(true); // saveTokens が呼ばれたか
+      check(
         container.read(authStateProvider).hasError,
-        isTrue,
-      ); // state が AsyncError か
+      ).equals(true); // state が AsyncError か
     });
 
     test('logout: トークンを削除し、state を false に更新すること', () async {
@@ -133,11 +129,10 @@ void main() {
       await notifier.logout();
 
       // Assert
-      expect(fakeStorage.isClearCalled, isTrue); // clear が呼ばれたか
-      expect(
+      check(fakeStorage.isClearCalled).equals(true); // clear が呼ばれたか
+      check(
         container.read(authStateProvider).value,
-        isFalse,
-      ); // state が false か
+      ).equals(false); // state が false か
     });
 
     test('logout: トークンの削除に失敗した場合、例外がスローされ state が AsyncError になること', () async {
@@ -153,14 +148,13 @@ void main() {
       await container.read(authStateProvider.future);
 
       // Act & Assert
-      await expectLater(notifier.logout, throwsException);
+      await check(notifier.logout()).throws<Exception>();
 
       // Assert
-      expect(fakeStorage.isClearCalled, isTrue); // clear が呼ばれたか
-      expect(
+      check(fakeStorage.isClearCalled).equals(true); // clear が呼ばれたか
+      check(
         container.read(authStateProvider).hasError,
-        isTrue,
-      ); // state が AsyncError か
+      ).equals(true); // state が AsyncError か
     });
   });
 }

--- a/test/src/features/auth/application/firebase_auth_state_notifier_test.dart
+++ b/test/src/features/auth/application/firebase_auth_state_notifier_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_sample/src/features/auth/application/firebase_auth_state_notifier.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
@@ -37,7 +38,7 @@ void main() {
         final state = container.read(firebaseAuthStateProvider);
 
         // Assert
-        expect(state, mockUser);
+        check(state).equals(mockUser);
       },
     );
 
@@ -61,7 +62,7 @@ void main() {
         final state = container.read(firebaseAuthStateProvider);
 
         // Assert
-        expect(state, isNull);
+        check(state).isNull();
       },
     );
 
@@ -88,7 +89,7 @@ void main() {
         final state = container.read(firebaseAuthStateProvider);
 
         // Assert
-        expect(state, isNull);
+        check(state).isNull();
 
         // 💡 修正2: Riverpodのエラー（Bad state）を回避するため、
         // テスト終了直前にダミーの値を流して「ロード状態」を平和に終わらせる

--- a/test/src/features/auth/data/auth_repository_test.dart
+++ b/test/src/features/auth/data/auth_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart'; // Responseクラス用
 import 'package:flutter_sample/src/core/network/api_client.dart';
 import 'package:flutter_sample/src/core/network/dio_provider.dart';
@@ -5,6 +6,7 @@ import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 
 // --- モックとFakeクラスの定義 ---
@@ -102,8 +104,8 @@ void main() {
       ).called(1);
 
       // 2. TokenStorageに正しい値が保存されたか
-      expect(fakeStorage.savedAccessToken, 'new_access_token');
-      expect(fakeStorage.savedRefreshToken, 'new_refresh_token');
+      check(fakeStorage.savedAccessToken).equals('new_access_token');
+      check(fakeStorage.savedRefreshToken).equals('new_refresh_token');
     });
 
     test('login: APIレスポンスにトークンが含まれていない場合、Exceptionを投げること', () async {
@@ -125,8 +127,9 @@ void main() {
       ).thenAnswer((_) async => mockResponse);
 
       // Act & Assert
-      await expectLater(
+      check(
         () => repo.login('test@example.com', 'password123'),
+      ).legacyMatcher(
         throwsA(
           isA<Exception>().having(
             (e) => e.toString(),
@@ -137,7 +140,7 @@ void main() {
       );
 
       // 例外が発生し、TokenStorageに保存処理が行われていないことを確認
-      expect(fakeStorage.savedAccessToken, isNull);
+      check(fakeStorage.savedAccessToken).isNull();
     });
 
     group('refreshToken', () {
@@ -151,7 +154,7 @@ void main() {
         final result = await repo.refreshToken();
 
         // Assert
-        expect(result, isFalse);
+        check(result).equals(false);
         // APIが一切呼ばれていないことを確認
         verifyNever(
           () => mockApi.post<Map<String, dynamic>>(
@@ -184,9 +187,9 @@ void main() {
         final result = await repo.refreshToken();
 
         // Assert
-        expect(result, isFalse);
+        check(result).equals(false);
         // 保存処理が呼ばれていない（プロパティがnullのまま）ことを確認
-        expect(fakeStorage.savedAccessToken, isNull);
+        check(fakeStorage.savedAccessToken).isNull();
       });
 
       test('APIから新しいアクセストークンを取得できた場合、保存して true を返すこと', () async {
@@ -213,7 +216,7 @@ void main() {
         final result = await repo.refreshToken();
 
         // Assert
-        expect(result, isTrue);
+        check(result).equals(true);
 
         // APIが正しいリフレッシュトークンを送信したか
         verify(
@@ -227,8 +230,8 @@ void main() {
         ).called(1);
 
         // 新しいアクセストークンと、既存のリフレッシュトークンが保存されたか
-        expect(fakeStorage.savedAccessToken, 'refreshed_access');
-        expect(fakeStorage.savedRefreshToken, 'valid_refresh');
+        check(fakeStorage.savedAccessToken).equals('refreshed_access');
+        check(fakeStorage.savedRefreshToken).equals('valid_refresh');
       });
     });
   });
@@ -245,7 +248,7 @@ void main() {
 
       final apiClient = container.read(authApiClientProvider);
 
-      expect(apiClient, isA<DioApiClient>());
+      check(apiClient).isA<DioApiClient>();
     });
   });
 
@@ -264,10 +267,10 @@ void main() {
         final repository = container.read(authRepositoryProvider);
 
         // 3. Assert (検証)
-        expect(repository, isA<AuthRepository>());
+        check(repository).isA<AuthRepository>();
 
-        expect(repository.api, equals(mockApi));
-        expect(repository.tokenStorage, equals(fakeStorage));
+        check(repository.api).equals(mockApi);
+        check(repository.tokenStorage).equals(fakeStorage);
       },
     );
   });

--- a/test/src/features/auth/data/auth_repository_test.dart
+++ b/test/src/features/auth/data/auth_repository_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 
 // --- モックとFakeクラスの定義 ---
@@ -127,17 +126,18 @@ void main() {
       ).thenAnswer((_) async => mockResponse);
 
       // Act & Assert
-      check(
-        () => repo.login('test@example.com', 'password123'),
-      ).legacyMatcher(
-        throwsA(
-          isA<Exception>().having(
-            (e) => e.toString(),
-            'message',
-            contains('Invalid token response from server'),
-          ),
-        ),
-      );
+      try {
+        await repo.login('test@example.com', 'password123');
+        fail('Exception not thrown');
+      } on Exception catch (e) {
+        check(e)
+            .isA<Exception>()
+            .has(
+              (e) => e.toString(),
+              'toString()',
+            )
+            .contains('Invalid token response from server');
+      }
 
       // 例外が発生し、TokenStorageに保存処理が行われていないことを確認
       check(fakeStorage.savedAccessToken).isNull();

--- a/test/src/features/auth/data/firebase_auth_repository_test.dart
+++ b/test/src/features/auth/data/firebase_auth_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_sample/src/core/utils/logger_provider.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
@@ -77,7 +78,7 @@ void main() {
 
       final asyncValue = container.read(authStateChangesProvider);
 
-      expect(asyncValue, isA<AsyncValue<User?>>());
+      check(asyncValue).isA<AsyncValue<User?>>();
       verify(() => mockFirebaseAuth.userChanges()).called(1);
     });
   });
@@ -153,7 +154,7 @@ void main() {
 
       final result = await repo.signInWithGoogle();
 
-      expect(result, isTrue);
+      check(result).equals(true);
       verify(() => mockGoogleSignIn.initialize()).called(1);
       verify(() => mockGoogleSignIn.authenticate()).called(1);
 
@@ -188,7 +189,7 @@ void main() {
 
       final result = await repo.signInWithGoogle();
 
-      expect(result, isFalse);
+      check(result).equals(false);
 
       verifyNever(
         () => mockFirebaseAuth.signInWithCredential(any<AuthCredential>()),
@@ -207,7 +208,7 @@ void main() {
 
         final result = await repo.signInWithGoogle();
 
-        expect(result, isFalse);
+        check(result).equals(false);
         verify(
           () => mockTalker.warning('SignInWithGoogle Error: $exception'),
         ).called(1);

--- a/test/src/features/auth/presentation/firebase_email_verification_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_email_verification_screen_test.dart
@@ -1,7 +1,9 @@
 // ignore_for_file: use_setters_to_change_properties, document_ignores
 
+import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/utils/app_lifecycle_provider.dart';
 import 'package:flutter_sample/src/features/auth/application/firebase_auth_state_notifier.dart';
@@ -119,11 +121,11 @@ void main() {
       await tester.pumpWidget(createTestWidget(container));
       await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(AppBar, 'メール認証'), findsOneWidget);
-      expect(find.text('確認メールを送信しました。'), findsOneWidget);
-      expect(find.text('認証を完了したか確認する'), findsOneWidget);
-      expect(find.text('再送信する'), findsOneWidget);
-      expect(find.text('ログアウトして戻る'), findsOneWidget);
+      check(find.widgetWithText(AppBar, 'メール認証')).findsOne();
+      check(find.text('確認メールを送信しました。')).findsOne();
+      check(find.text('認証を完了したか確認する')).findsOne();
+      check(find.text('再送信する')).findsOne();
+      check(find.text('ログアウトして戻る')).findsOne();
     });
 
     testWidgets('手動確認ボタンタップ時、ローディング表示になりリロード処理が呼ばれること', (tester) async {
@@ -153,13 +155,13 @@ void main() {
       // ポンプして画面を再描画（まだ非同期処理は終わっていない）
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      check(find.byType(CircularProgressIndicator)).findsOne();
 
       // 非同期処理を最後まで完了させる
       await tester.pumpAndSettle();
 
       // ローディングが消え、処理が呼ばれたことを確認
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      check(find.byType(CircularProgressIndicator)).findsNothing();
       verify(() => mockAuthRepo.reloadCurrentUser()).called(1);
     });
 
@@ -183,7 +185,7 @@ void main() {
 
       verify(() => mockAuthRepo.sendEmailVerification()).called(1);
       // 処理成功後にスナックバーが表示されていることを確認
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
     });
 
     testWidgets('再送信処理でエラーが起きた場合、エラースナックバーが表示されること', (tester) async {
@@ -211,7 +213,7 @@ void main() {
 
       verify(() => mockAuthRepo.sendEmailVerification()).called(1);
       // ErrorHandler 経由でエラースナックバーが表示されることを確認
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
     });
 
     testWidgets('アプリがバックグラウンドから復帰(resumed)した時、ユーザー情報がリロードされること', (
@@ -272,7 +274,7 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(() => mockAuthRepo.reloadCurrentUser()).called(1);
-        expect(find.byType(SnackBar), findsOneWidget);
+        check(find.byType(SnackBar)).findsOne();
       },
     );
 
@@ -303,7 +305,7 @@ void main() {
       verify(() => mockAuthRepo.reloadCurrentUser()).called(1);
 
       // ErrorHandler 経由でエラースナックバーが表示されることを確認（61行目の通過）
-      expect(find.byType(SnackBar), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
     });
 
     testWidgets('ログアウトして戻るボタンをタップすると、サインアウト処理が呼ばれること', (tester) async {

--- a/test/src/features/auth/presentation/firebase_login_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_login_screen_test.dart
@@ -1,5 +1,7 @@
+import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
 import 'package:flutter_sample/src/features/auth/presentation/firebase_login_screen.dart';
@@ -78,20 +80,20 @@ void main() {
   group('FirebaseLoginScreen', () {
     test('コンストラクタでインスタンスが生成できること', () {
       const screen = FirebaseLoginScreen();
-      expect(screen, isA<FirebaseLoginScreen>());
+      check(screen).isA<FirebaseLoginScreen>();
     });
 
     testWidgets('UIが正しくレンダリングされること', (tester) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(AppBar, 'ログイン'), findsOneWidget);
-      expect(find.text('メールアドレス'), findsOneWidget);
-      expect(find.text('パスワード'), findsOneWidget);
-      expect(find.text('ログインする'), findsOneWidget);
-      expect(find.text('新規登録へ'), findsOneWidget);
-      expect(find.text('Googleでログイン'), findsOneWidget);
-      expect(find.text('パスワードをお忘れですか？'), findsOneWidget);
+      check(find.widgetWithText(AppBar, 'ログイン')).findsOne();
+      check(find.text('メールアドレス')).findsOne();
+      check(find.text('パスワード')).findsOne();
+      check(find.text('ログインする')).findsOne();
+      check(find.text('新規登録へ')).findsOne();
+      check(find.text('Googleでログイン')).findsOne();
+      check(find.text('パスワードをお忘れですか？')).findsOne();
     });
 
     group('メール・パスワードログイン', () {
@@ -139,19 +141,18 @@ void main() {
         await tester.pump();
 
         // インジケーターが表示されていること（特定のボタン内を探す）
-        expect(
+        check(
           find.descendant(
             of: find.widgetWithText(FilledButton, 'ログインする'),
             matching: find.byType(CircularProgressIndicator),
           ),
-          findsOneWidget,
-        );
+        ).findsOne();
 
         // 非同期処理を完了させる
         await tester.pumpAndSettle();
 
         // ローディングが終了していること
-        expect(find.byType(CircularProgressIndicator), findsNothing);
+        check(find.byType(CircularProgressIndicator)).findsNothing();
       });
 
       testWidgets('ログイン失敗時(FirebaseAuthException発生時)、専用のSnackBarが表示されること', (
@@ -171,8 +172,8 @@ void main() {
         await tester.pump();
 
         // SnackBar とテキストが表示されているか確認
-        expect(find.byType(SnackBar), findsOneWidget);
-        expect(find.text('ログインに失敗しました'), findsOneWidget);
+        check(find.byType(SnackBar)).findsOne();
+        check(find.text('ログインに失敗しました')).findsOne();
       });
     });
 
@@ -185,7 +186,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // 画面遷移したことを確認
-        expect(find.textContaining('Navigated to'), findsOneWidget);
+        check(find.textContaining('Navigated to')).findsOne();
       });
     });
 
@@ -218,8 +219,8 @@ void main() {
         verify(() => mockAuthRepo.signInWithGoogle()).called(1);
 
         // 画面遷移せず、エラーSnackBarも出ないことを確認
-        expect(find.textContaining('Navigated to'), findsNothing);
-        expect(find.byType(SnackBar), findsNothing);
+        check(find.textContaining('Navigated to')).findsNothing();
+        check(find.byType(SnackBar)).findsNothing();
       });
 
       testWidgets('ログイン処理中、ローディングインジケーターが表示されること', (tester) async {
@@ -236,13 +237,12 @@ void main() {
         await tester.tap(find.text('Googleでログイン'));
         await tester.pump();
 
-        expect(
+        check(
           find.descendant(
             of: find.widgetWithText(ElevatedButton, 'Googleでログイン'),
             matching: find.byType(CircularProgressIndicator),
           ),
-          findsOneWidget,
-        );
+        ).findsOne();
 
         await tester.pumpAndSettle();
       });
@@ -263,8 +263,8 @@ void main() {
         verify(() => mockAuthRepo.signInWithGoogle()).called(1);
 
         // 一般的な Exception なので ErrorHandler が「予期しないエラー」にフォールバックすることを確認
-        expect(find.byType(SnackBar), findsOneWidget);
-        expect(find.text('予期しないエラーが発生しました'), findsOneWidget);
+        check(find.byType(SnackBar)).findsOne();
+        check(find.text('予期しないエラーが発生しました')).findsOne();
       });
     });
 
@@ -285,7 +285,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // 画面遷移したことを確認
-        expect(find.textContaining('Navigated to'), findsOneWidget);
+        check(find.textContaining('Navigated to')).findsOne();
       });
     });
 
@@ -298,13 +298,13 @@ void main() {
       await tester.pumpAndSettle();
 
       final BuildContext context = tester.element(textFields.first);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // AppBarなど画面外をタップ
       await tester.tap(find.byType(AppBar));
       await tester.pumpAndSettle();
 
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
     });
   });
 }

--- a/test/src/features/auth/presentation/firebase_login_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_login_screen_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors, document_ignores
 import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -58,7 +59,7 @@ void main() {
       routes: [
         GoRoute(
           path: '/login',
-          builder: (context, state) => const FirebaseLoginScreen(),
+          builder: (context, state) => FirebaseLoginScreen(),
         ),
       ],
       errorBuilder: (context, state) => Scaffold(
@@ -79,7 +80,7 @@ void main() {
 
   group('FirebaseLoginScreen', () {
     test('コンストラクタでインスタンスが生成できること', () {
-      const screen = FirebaseLoginScreen();
+      final screen = FirebaseLoginScreen();
       check(screen).isA<FirebaseLoginScreen>();
     });
 

--- a/test/src/features/auth/presentation/firebase_reset_password_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_reset_password_screen_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors, document_ignores
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
@@ -65,7 +66,7 @@ void main() {
         ),
         GoRoute(
           path: '/reset',
-          builder: (context, state) => const FirebaseResetPasswordScreen(),
+          builder: (context, state) => FirebaseResetPasswordScreen(),
         ),
       ],
     );

--- a/test/src/features/auth/presentation/firebase_reset_password_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_reset_password_screen_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
 import 'package:flutter_sample/src/features/auth/presentation/firebase_reset_password_screen.dart';
@@ -91,9 +93,9 @@ void main() {
     testWidgets('UIが正しくレンダリングされること', (tester) async {
       await navigateToResetScreen(tester);
 
-      expect(find.widgetWithText(AppBar, 'パスワード再設定'), findsOneWidget);
-      expect(find.text('メールアドレス'), findsOneWidget);
-      expect(find.text('送信する'), findsOneWidget);
+      check(find.widgetWithText(AppBar, 'パスワード再設定')).findsOne();
+      check(find.text('メールアドレス')).findsOne();
+      check(find.text('送信する')).findsOne();
     });
 
     testWidgets('未入力でボタンを押した場合は何も起きないこと(バリデーション)', (tester) async {
@@ -127,13 +129,13 @@ void main() {
       await tester.pump();
 
       // インジケーターが表示されていること
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      check(find.byType(CircularProgressIndicator)).findsOne();
 
       // 非同期処理を完了させる
       await tester.pumpAndSettle();
 
       // ローディングが終了していること
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      check(find.byType(CircularProgressIndicator)).findsNothing();
     });
 
     testWidgets('送信成功時、SnackBarが表示され、前の画面に pop() されること', (tester) async {
@@ -155,15 +157,15 @@ void main() {
       ).called(1);
 
       // SnackBar が表示されているか検証
-      expect(find.byType(SnackBar), findsWidgets);
-      expect(find.text('再設定メールを送信しました'), findsWidgets);
+      check(find.byType(SnackBar)).findsAny();
+      check(find.text('再設定メールを送信しました')).findsAny();
 
       // アニメーションを最後まで完了させる (pop の画面遷移を含む)
       await tester.pumpAndSettle();
 
       // 💡 元のダミーホーム画面に戻っていること（= popが成功していること）を確認
-      expect(find.text('Go Reset'), findsOneWidget);
-      expect(find.widgetWithText(AppBar, 'パスワード再設定'), findsNothing);
+      check(find.text('Go Reset')).findsOne();
+      check(find.widgetWithText(AppBar, 'パスワード再設定')).findsNothing();
     });
 
     testWidgets('送信失敗時(Exception発生時)、汎用のエラーSnackBarが表示されること', (tester) async {
@@ -179,11 +181,11 @@ void main() {
       await tester.pump(); // SnackBar描画のために1フレーム進める
 
       // 💡 ErrorHandler によって「予期しないエラー」の SnackBar が出ること
-      expect(find.byType(SnackBar), findsOneWidget);
-      expect(find.text('予期しないエラーが発生しました'), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
+      check(find.text('予期しないエラーが発生しました')).findsOne();
 
       // エラー時は画面が pop されず残っていることを確認
-      expect(find.widgetWithText(AppBar, 'パスワード再設定'), findsOneWidget);
+      check(find.widgetWithText(AppBar, 'パスワード再設定')).findsOne();
     });
 
     testWidgets('画面外タップでキーボードが閉じること', (tester) async {
@@ -194,13 +196,13 @@ void main() {
       await tester.pumpAndSettle();
 
       final BuildContext context = tester.element(textFields.first);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // AppBarなど画面外をタップ
       await tester.tap(find.byType(AppBar));
       await tester.pumpAndSettle();
 
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
     });
   });
 }

--- a/test/src/features/auth/presentation/firebase_sign_up_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_sign_up_screen_test.dart
@@ -1,5 +1,7 @@
+import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
 import 'package:flutter_sample/src/features/auth/presentation/firebase_sign_up_screen.dart';
@@ -82,11 +84,11 @@ void main() {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(AppBar, '新規登録'), findsOneWidget);
-      expect(find.text('メールアドレス'), findsOneWidget);
-      expect(find.text('パスワード'), findsOneWidget);
-      expect(find.text('登録する'), findsOneWidget);
-      expect(find.text('ログインへ戻る'), findsOneWidget);
+      check(find.widgetWithText(AppBar, '新規登録')).findsOne();
+      check(find.text('メールアドレス')).findsOne();
+      check(find.text('パスワード')).findsOne();
+      check(find.text('登録する')).findsOne();
+      check(find.text('ログインへ戻る')).findsOne();
     });
 
     testWidgets('未入力でボタンを押した場合は何も起きないこと(バリデーション)', (tester) async {
@@ -153,13 +155,13 @@ void main() {
       await tester.pump();
 
       // インジケーターが表示されていること
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      check(find.byType(CircularProgressIndicator)).findsOne();
 
       // 非同期処理を完了させる
       await tester.pumpAndSettle();
 
       // ローディングが終了していること
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      check(find.byType(CircularProgressIndicator)).findsNothing();
     });
 
     testWidgets('サインアップ失敗時(Firebaseエラー)、専用のSnackBarが表示され画面遷移しないこと', (
@@ -182,12 +184,12 @@ void main() {
       await tester.pump();
 
       // ErrorHandler が翻訳した「既に登録されています」の文言が表示されることを確認
-      expect(find.byType(SnackBar), findsOneWidget);
-      expect(find.text('このメールアドレスは既に登録されています'), findsOneWidget);
+      check(find.byType(SnackBar)).findsOne();
+      check(find.text('このメールアドレスは既に登録されています')).findsOne();
 
       // 確認メール送信が呼ばれていないこと、画面遷移していないことを確認
       verifyNever(() => mockAuthRepo.sendEmailVerification());
-      expect(find.textContaining('Navigated to'), findsNothing);
+      check(find.textContaining('Navigated to')).findsNothing();
     });
 
     testWidgets('画面外タップでキーボードが閉じること', (tester) async {
@@ -199,13 +201,13 @@ void main() {
       await tester.pumpAndSettle();
 
       final BuildContext context = tester.element(textFields.first);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // AppBarなど画面外をタップ
       await tester.tap(find.byType(AppBar));
       await tester.pumpAndSettle();
 
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
     });
   });
 }

--- a/test/src/features/auth/presentation/firebase_sign_up_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_sign_up_screen_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors, document_ignores
 import 'package:checks/checks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -59,7 +60,7 @@ void main() {
       routes: [
         GoRoute(
           path: '/signup',
-          builder: (context, state) => const FirebaseSignUpScreen(),
+          builder: (context, state) => FirebaseSignUpScreen(),
         ),
       ],
       // 成功時に EmailVerificationRoute などへ遷移したことをキャッチする

--- a/test/src/features/auth/presentation/login_screen_test.dart
+++ b/test/src/features/auth/presentation/login_screen_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors, document_ignores
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
@@ -85,7 +86,7 @@ void main() {
       routes: [
         GoRoute(
           path: '/login',
-          builder: (context, state) => const LoginScreen(),
+          builder: (context, state) => LoginScreen(),
         ),
       ],
     );
@@ -108,7 +109,7 @@ void main() {
 
   group('LoginScreen (API)', () {
     test('コンストラクタでインスタンスが生成できること', () {
-      const screen = LoginScreen();
+      final screen = LoginScreen();
       check(screen).isA<LoginScreen>();
     });
 

--- a/test/src/features/auth/presentation/login_screen_test.dart
+++ b/test/src/features/auth/presentation/login_screen_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/analytics/analytics_event.dart';
 import 'package:flutter_sample/src/core/analytics/analytics_service.dart';
@@ -107,17 +109,17 @@ void main() {
   group('LoginScreen (API)', () {
     test('コンストラクタでインスタンスが生成できること', () {
       const screen = LoginScreen();
-      expect(screen, isA<LoginScreen>());
+      check(screen).isA<LoginScreen>();
     });
 
     testWidgets('UIが正しくレンダリングされること', (tester) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(AppBar, 'ログイン'), findsOneWidget);
-      expect(find.text('メールアドレス'), findsOneWidget);
-      expect(find.text('パスワード'), findsOneWidget);
-      expect(find.text('ログインする'), findsOneWidget);
+      check(find.widgetWithText(AppBar, 'ログイン')).findsOne();
+      check(find.text('メールアドレス')).findsOne();
+      check(find.text('パスワード')).findsOne();
+      check(find.text('ログインする')).findsOne();
     });
 
     testWidgets('未入力でボタンを押した場合は何も起きないこと(バリデーション)', (tester) async {
@@ -128,7 +130,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Fakeのメソッドが呼ばれていないことと、Analyticsが呼ばれていないことを確認
-      expect(loginCallCount, 0);
+      check(loginCallCount).equals(0);
       verifyZeroInteractions(mockAnalyticsService);
     });
 
@@ -148,11 +150,11 @@ void main() {
       // ポンプして画面を再描画
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      check(find.byType(CircularProgressIndicator)).findsOne();
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      check(find.byType(CircularProgressIndicator)).findsNothing();
     });
 
     testWidgets('ログイン成功時、SnackBarが表示され、Analyticsにログが送信されること', (tester) async {
@@ -167,15 +169,15 @@ void main() {
       await tester.pump();
 
       // Fakeメソッドが呼ばれたか
-      expect(loginCallCount, 1);
+      check(loginCallCount).equals(1);
 
       // Analyticsが呼ばれたか
       verify(
         () => mockAnalyticsService.logEvent(event: AnalyticsEvent.loginSuccess),
       ).called(1);
 
-      expect(find.byType(SnackBar), findsWidgets);
-      expect(find.text('ログイン成功！'), findsWidgets);
+      check(find.byType(SnackBar)).findsAny();
+      check(find.text('ログイン成功！')).findsAny();
 
       await tester.pumpAndSettle();
     });
@@ -198,16 +200,16 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
-      expect(find.byType(AlertDialog), findsOneWidget);
-      expect(find.text('エラーが発生しました'), findsOneWidget);
-      expect(find.text('予期しないエラーが発生しました'), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
+      check(find.text('エラーが発生しました')).findsOne();
+      check(find.text('予期しないエラーが発生しました')).findsOne();
 
       // ダイアログのOKボタンを押して閉じる
       await tester.tap(find.text('OK'));
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsNothing);
+      check(find.byType(AlertDialog)).findsNothing();
     });
 
     testWidgets('画面外タップでキーボードが閉じること', (tester) async {
@@ -219,13 +221,13 @@ void main() {
       await tester.pumpAndSettle();
 
       final BuildContext context = tester.element(textFields.first);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // AppBarなど画面外をタップ
       await tester.tap(find.byType(AppBar));
       await tester.pumpAndSettle();
 
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
     });
   });
 }

--- a/test/src/features/chart/application/chart_notifier_test.dart
+++ b/test/src/features/chart/application/chart_notifier_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/utils/uuid_provider.dart';
 import 'package:flutter_sample/src/features/chart/application/chart_notifier.dart';
 import 'package:flutter_sample/src/features/chart/domain/chart_type.dart';
@@ -30,14 +31,14 @@ void main() {
       final container = makeProviderContainer();
       final state = container.read(chartProvider);
 
-      expect(state.items.length, 2);
-      expect(state.chartType, ChartType.line);
+      check(state.items.length).equals(2);
+      check(state.chartType).equals(ChartType.line);
     });
 
     test('グラフの種類を更新できること', () {
       final container = makeProviderContainer();
       container.read(chartProvider.notifier).updateChartType(ChartType.bar);
-      expect(container.read(chartProvider).chartType, ChartType.bar);
+      check(container.read(chartProvider).chartType).equals(ChartType.bar);
     });
 
     test('項目を追加できること (UUIDモック使用)', () {
@@ -48,9 +49,9 @@ void main() {
       container.read(chartProvider.notifier).addItem();
 
       final items = container.read(chartProvider).items;
-      expect(items.length, 3);
-      expect(items.last.id, generatedId);
-      expect(items.last.label, 'Item3');
+      check(items.length).equals(3);
+      check(items.last.id).equals(generatedId);
+      check(items.last.label).equals('Item3');
       verify(() => mockUuid.v4()).called(1);
     });
 
@@ -61,15 +62,14 @@ void main() {
 
       // Item1(id1) を削除 -> 現在は Item2 のみ
       container.read(chartProvider.notifier).removeItem(id1);
-      expect(container.read(chartProvider).items.length, 1);
+      check(container.read(chartProvider).items.length).equals(1);
 
       // 追加 -> Item2 があるので、次は Item3 になるべき（Item2とは重複しない）
       container.read(chartProvider.notifier).addItem();
-      expect(container.read(chartProvider).items.length, 2);
-      expect(
+      check(container.read(chartProvider).items.length).equals(2);
+      check(
         container.read(chartProvider).items.any((i) => i.label == 'Item3'),
-        isTrue,
-      );
+      ).equals(true);
     });
 
     test('項目を削除できること', () {
@@ -77,11 +77,10 @@ void main() {
       final firstId = container.read(chartProvider).items.first.id;
 
       container.read(chartProvider.notifier).removeItem(firstId);
-      expect(container.read(chartProvider).items.length, 1);
-      expect(
+      check(container.read(chartProvider).items.length).equals(1);
+      check(
         container.read(chartProvider).items.any((i) => i.id == firstId),
-        isFalse,
-      );
+      ).equals(false);
     });
 
     test('reset: 全ての項目が削除されカウンターがリセットされること', () {
@@ -89,8 +88,8 @@ void main() {
       container.read(chartProvider.notifier).reset();
 
       final state = container.read(chartProvider);
-      expect(state.items, isEmpty);
-      expect(state.itemCounter, 0);
+      check(state.items).isEmpty();
+      check(state.itemCounter).equals(0);
     });
 
     test('ラベルを更新できること', () {
@@ -98,7 +97,7 @@ void main() {
       final firstId = container.read(chartProvider).items.first.id;
 
       container.read(chartProvider.notifier).updateLabel(firstId, '更新済み');
-      expect(container.read(chartProvider).items.first.label, '更新済み');
+      check(container.read(chartProvider).items.first.label).equals('更新済み');
     });
 
     test('数値を更新できること', () {
@@ -106,7 +105,7 @@ void main() {
       final firstId = container.read(chartProvider).items.first.id;
 
       container.read(chartProvider.notifier).updateValue(firstId, 100.5);
-      expect(container.read(chartProvider).items.first.value, 100.5);
+      check(container.read(chartProvider).items.first.value).equals(100.5);
     });
   });
 }

--- a/test/src/features/chart/domain/chart_item_test.dart
+++ b/test/src/features/chart/domain/chart_item_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/chart/domain/chart_item.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -6,17 +7,17 @@ void main() {
     test('デフォルト値が正しく設定されること', () {
       const item = ChartItem(id: 'test-id');
 
-      expect(item.id, 'test-id');
-      expect(item.label, '');
-      expect(item.value, 0.0);
+      check(item.id).equals('test-id');
+      check(item.label).equals('');
+      check(item.value).equals(0);
     });
 
     test('指定した値でインスタンスが生成されること', () {
       const item = ChartItem(id: 'test-id', label: 'Item 1', value: 10.5);
 
-      expect(item.id, 'test-id');
-      expect(item.label, 'Item 1');
-      expect(item.value, 10.5);
+      check(item.id).equals('test-id');
+      check(item.label).equals('Item 1');
+      check(item.value).equals(10.5);
     });
 
     test('fromJsonで正しくインスタンスが生成されること', () {
@@ -28,16 +29,16 @@ void main() {
 
       final item = ChartItem.fromJson(json);
 
-      expect(item.id, 'test-id');
-      expect(item.label, 'Item 1');
-      expect(item.value, 10.5);
+      check(item.id).equals('test-id');
+      check(item.label).equals('Item 1');
+      check(item.value).equals(10.5);
     });
 
     test('toJsonで正しいMapに変換されること', () {
       const item = ChartItem(id: 'test-id', label: 'Item 1', value: 10.5);
       final json = item.toJson();
 
-      expect(json, {
+      check(json).deepEquals({
         'id': 'test-id',
         'label': 'Item 1',
         'value': 10.5,

--- a/test/src/features/chart/domain/chart_type_test.dart
+++ b/test/src/features/chart/domain/chart_type_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/chart/domain/chart_type.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,19 +16,19 @@ void main() {
 
     test('getLocalizedLabelがlineのとき正しいラベルを返すこと', () {
       when(() => mockL10n.chartLine).thenReturn('折れ線グラフ');
-      expect(ChartType.line.getLocalizedLabel(mockL10n), '折れ線グラフ');
+      check(ChartType.line.getLocalizedLabel(mockL10n)).equals('折れ線グラフ');
       verify(() => mockL10n.chartLine).called(1);
     });
 
     test('getLocalizedLabelがbarのとき正しいラベルを返すこと', () {
       when(() => mockL10n.chartBar).thenReturn('棒グラフ');
-      expect(ChartType.bar.getLocalizedLabel(mockL10n), '棒グラフ');
+      check(ChartType.bar.getLocalizedLabel(mockL10n)).equals('棒グラフ');
       verify(() => mockL10n.chartBar).called(1);
     });
 
     test('getLocalizedLabelがpieのとき正しいラベルを返すこと', () {
       when(() => mockL10n.chartPie).thenReturn('円グラフ');
-      expect(ChartType.pie.getLocalizedLabel(mockL10n), '円グラフ');
+      check(ChartType.pie.getLocalizedLabel(mockL10n)).equals('円グラフ');
       verify(() => mockL10n.chartPie).called(1);
     });
   });

--- a/test/src/features/chart/presentation/chart_display_screen_test.dart
+++ b/test/src/features/chart/presentation/chart_display_screen_test.dart
@@ -1,5 +1,7 @@
+import 'package:checks/checks.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/chart/application/chart_notifier.dart';
 import 'package:flutter_sample/src/features/chart/domain/chart_type.dart';
@@ -38,8 +40,8 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest(container));
       await tester.pumpAndSettle();
 
-      expect(find.byType(LineChart), findsOneWidget);
-      expect(find.text('Item1'), findsWidgets);
+      check(find.byType(LineChart)).findsOne();
+      check(find.text('Item1')).findsAny();
 
       // 数値テキストをスクロールして見つける
       final valueText = find.text('10.0');
@@ -48,10 +50,10 @@ void main() {
         find.byType(CustomScrollView),
         const Offset(0, -300),
       );
-      expect(valueText, findsOneWidget);
+      check(valueText).findsOne();
 
       // 新しいデザイン要素の確認
-      expect(find.text('データ一覧'), findsOneWidget);
+      check(find.text('データ一覧')).findsOne();
     });
 
     testWidgets('棒グラフが正しく表示されること', (tester) async {
@@ -60,8 +62,8 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest(container));
       await tester.pumpAndSettle();
 
-      expect(find.byType(BarChart), findsOneWidget);
-      expect(find.text('Item2'), findsWidgets);
+      check(find.byType(BarChart)).findsOne();
+      check(find.text('Item2')).findsAny();
 
       final valueText = find.text('20.0');
       await tester.dragUntilVisible(
@@ -69,7 +71,7 @@ void main() {
         find.byType(CustomScrollView),
         const Offset(0, -300),
       );
-      expect(valueText, findsOneWidget);
+      check(valueText).findsOne();
     });
 
     testWidgets('円グラフが正しく表示され、カラーのループが動作すること', (tester) async {
@@ -82,13 +84,12 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest(container));
       await tester.pumpAndSettle();
 
-      expect(find.byType(PieChart), findsOneWidget);
+      check(find.byType(PieChart)).findsOne();
       final pieChart = tester.widget<PieChart>(find.byType(PieChart));
       // 0番目と6番目の色が同じであることを確認 (moduloの検証)
-      expect(
+      check(
         pieChart.data.sections[0].color,
-        pieChart.data.sections[6].color,
-      );
+      ).equals(pieChart.data.sections[6].color);
     });
 
     testWidgets('データが空の場合にメッセージが表示されること', (tester) async {
@@ -98,8 +99,8 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest(container));
       await tester.pumpAndSettle();
 
-      expect(find.text('データがありません。まず項目を追加してください。'), findsOneWidget);
-      expect(find.byType(LineChart), findsNothing);
+      check(find.text('データがありません。まず項目を追加してください。')).findsOne();
+      check(find.byType(LineChart)).findsNothing();
     });
 
     testWidgets('LineChartのX軸タイトル: 整数以外、間引き、範囲外の検証', (tester) async {
@@ -112,16 +113,16 @@ void main() {
       final mockMeta = MockTitleMeta();
 
       // 1. 整数以外は SizedBox.shrink
-      expect(titlesData.getTitlesWidget(0.5, mockMeta), isA<SizedBox>());
+      check(titlesData.getTitlesWidget(0.5, mockMeta)).isA<SizedBox>();
 
       // 2. 正常なインデックス
       final valid = titlesData.getTitlesWidget(0, mockMeta);
-      expect(valid, isA<SideTitleWidget>());
-      expect(((valid as SideTitleWidget).child as Text).data, 'Item1');
+      check(valid).isA<SideTitleWidget>();
+      check(((valid as SideTitleWidget).child as Text).data).equals('Item1');
 
       // 3. 範囲外
-      expect(titlesData.getTitlesWidget(-1, mockMeta), isA<SizedBox>());
-      expect(titlesData.getTitlesWidget(100, mockMeta), isA<SizedBox>());
+      check(titlesData.getTitlesWidget(-1, mockMeta)).isA<SizedBox>();
+      check(titlesData.getTitlesWidget(100, mockMeta)).isA<SizedBox>();
 
       // 4. 間引きの検証 (項目を11個にして interval=2 にする)
       for (var i = 0; i < 9; i++) {
@@ -133,7 +134,7 @@ void main() {
       final titlesData2 = lineChart2.data.titlesData.bottomTitles.sideTitles;
 
       // index 1 は間引かれる (1 % 2 != 0)
-      expect(titlesData2.getTitlesWidget(1, mockMeta), isA<SizedBox>());
+      check(titlesData2.getTitlesWidget(1, mockMeta)).isA<SizedBox>();
     });
 
     testWidgets('BarChartのX軸タイトル: 整数以外、間引き、範囲外の検証', (tester) async {
@@ -146,14 +147,14 @@ void main() {
       final mockMeta = MockTitleMeta();
 
       // 1. 整数以外
-      expect(titlesData.getTitlesWidget(0.1, mockMeta), isA<SizedBox>());
+      check(titlesData.getTitlesWidget(0.1, mockMeta)).isA<SizedBox>();
 
       // 2. 正常
       final valid = titlesData.getTitlesWidget(0, mockMeta);
-      expect(valid, isA<SideTitleWidget>());
+      check(valid).isA<SideTitleWidget>();
 
       // 3. 範囲外
-      expect(titlesData.getTitlesWidget(99, mockMeta), isA<SizedBox>());
+      check(titlesData.getTitlesWidget(99, mockMeta)).isA<SizedBox>();
 
       // 4. 間引き (21個にして interval=5 にする)
       for (var i = 0; i < 19; i++) {
@@ -165,7 +166,7 @@ void main() {
       final titlesData2 = barChart2.data.titlesData.bottomTitles.sideTitles;
 
       // index 1 は間引かれる (1 % 5 != 0)
-      expect(titlesData2.getTitlesWidget(1, mockMeta), isA<SizedBox>());
+      check(titlesData2.getTitlesWidget(1, mockMeta)).isA<SizedBox>();
     });
 
     testWidgets('左軸(Y軸)のラベルが正しくレンダリングされること', (tester) async {
@@ -176,8 +177,8 @@ void main() {
       final leftTitles = lineChart.data.titlesData.leftTitles.sideTitles;
 
       final widget = leftTitles.getTitlesWidget(10, MockTitleMeta());
-      expect(widget, isA<Text>());
-      expect((widget as Text).data, '10');
+      check(widget).isA<Text>();
+      check((widget as Text).data).equals('10');
     });
   });
 }

--- a/test/src/features/chart/presentation/chart_input_screen_test.dart
+++ b/test/src/features/chart/presentation/chart_input_screen_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/chart/application/chart_notifier.dart';
 import 'package:flutter_sample/src/features/chart/domain/chart_type.dart';
@@ -52,16 +54,16 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest(container, router));
       await tester.pumpAndSettle();
 
-      expect(find.byType(ChartInputScreen), findsOneWidget);
-      expect(find.byType(SegmentedButton<ChartType>), findsOneWidget);
-      expect(find.text('Item1'), findsOneWidget); // Default item 1 label
-      expect(find.text('10.0'), findsOneWidget); // Default item 1 value
-      expect(find.text('Item2'), findsOneWidget); // Default item 2 label
-      expect(find.text('20.0'), findsOneWidget); // Default item 2 value
+      check(find.byType(ChartInputScreen)).findsOne();
+      check(find.byType(SegmentedButton<ChartType>)).findsOne();
+      check(find.text('Item1')).findsOne(); // Default item 1 label
+      check(find.text('10.0')).findsOne(); // Default item 1 value
+      check(find.text('Item2')).findsOne(); // Default item 2 label
+      check(find.text('20.0')).findsOne(); // Default item 2 value
 
       // 新しいデザインの確認
-      expect(find.byType(Card), findsAtLeast(2));
-      expect(find.byIcon(Icons.label_outline), findsAtLeast(2));
+      check(find.byType(Card)).findsAtLeast(2);
+      check(find.byIcon(Icons.label_outline)).findsAtLeast(2);
     });
 
     testWidgets('グラフ種類を変更できること', (tester) async {
@@ -69,14 +71,14 @@ void main() {
       await tester.pumpAndSettle();
 
       final stateBefore = container.read(chartProvider);
-      expect(stateBefore.chartType, ChartType.line);
+      check(stateBefore.chartType).equals(ChartType.line);
 
       // 棒グラフを選択
       await tester.tap(find.text('棒グラフ'));
       await tester.pumpAndSettle();
 
       final stateAfter = container.read(chartProvider);
-      expect(stateAfter.chartType, ChartType.bar);
+      check(stateAfter.chartType).equals(ChartType.bar);
     });
 
     testWidgets('ラベルを更新できること', (tester) async {
@@ -90,7 +92,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final state = container.read(chartProvider);
-      expect(state.items[0].label, 'UpdatedLabel');
+      check(state.items[0].label).equals('UpdatedLabel');
     });
 
     testWidgets('数値を更新できること（正常な数値）', (tester) async {
@@ -102,7 +104,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final state = container.read(chartProvider);
-      expect(state.items[0].value, 50.5);
+      check(state.items[0].value).equals(50.5);
     });
 
     testWidgets('項目を追加できること', (tester) async {
@@ -114,8 +116,8 @@ void main() {
       await tester.pumpAndSettle();
 
       final state = container.read(chartProvider);
-      expect(state.items.length, 3);
-      expect(state.items[2].label, 'Item3');
+      check(state.items.length).equals(3);
+      check(state.items[2].label).equals('Item3');
     });
 
     testWidgets('項目を削除できること', (tester) async {
@@ -123,14 +125,14 @@ void main() {
       await tester.pumpAndSettle();
 
       final deleteBtns = find.byIcon(Icons.remove_circle_outline);
-      expect(deleteBtns, findsNWidgets(2));
+      check(deleteBtns).findsExactly(2);
 
       await tester.tap(deleteBtns.first);
       await tester.pumpAndSettle();
 
       final state = container.read(chartProvider);
-      expect(state.items.length, 1);
-      expect(state.items[0].label, 'Item2');
+      check(state.items.length).equals(1);
+      check(state.items[0].label).equals('Item2');
     });
 
     testWidgets('全削除ボタンが動作すること', (tester) async {
@@ -138,18 +140,18 @@ void main() {
       await tester.pumpAndSettle();
 
       // 初期状態で2つあることを確認
-      expect(container.read(chartProvider).items.length, 2);
+      check(container.read(chartProvider).items.length).equals(2);
 
       // 1. キャンセルする場合
       await tester.tap(find.byIcon(Icons.delete_sweep_outlined));
       await tester.pumpAndSettle();
-      expect(find.byType(AlertDialog), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
 
       await tester.tap(find.widgetWithText(TextButton, '閉じる'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsNothing);
-      expect(container.read(chartProvider).items.length, 2); // 削除されていないこと
+      check(find.byType(AlertDialog)).findsNothing();
+      check(container.read(chartProvider).items.length).equals(2); // 削除されていないこと
 
       // 2. 実行する場合
       await tester.tap(find.byIcon(Icons.delete_sweep_outlined));
@@ -160,8 +162,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // 項目が空になっていること
-      expect(container.read(chartProvider).items, isEmpty);
-      expect(find.text('データがありません。まず項目を追加してください。'), findsOneWidget);
+      check(container.read(chartProvider).items).isEmpty();
+      check(find.text('データがありません。まず項目を追加してください。')).findsOne();
     });
 
     testWidgets('グラフ表示画面への遷移ボタンが動作すること', (tester) async {
@@ -173,7 +175,7 @@ void main() {
       await tester.tap(viewBtn);
       await tester.pumpAndSettle();
 
-      expect(find.text('Display'), findsOneWidget);
+      check(find.text('Display')).findsOne();
     });
 
     testWidgets('画面外タップでキーボードが閉じること', (tester) async {
@@ -186,14 +188,14 @@ void main() {
 
       // Focusが当たっていることを確認
       final BuildContext context = tester.element(textFields.first);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // AppBarなど画面外をタップ
       await tester.tap(find.byType(AppBar));
       await tester.pumpAndSettle();
 
       // Focusが外れていることを確認
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
     });
   });
 }

--- a/test/src/features/chat/application/chat_notifier_test.dart
+++ b/test/src/features/chat/application/chat_notifier_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/core/utils/date_time_provider.dart';
 import 'package:flutter_sample/src/core/utils/uuid_provider.dart';
 import 'package:flutter_sample/src/features/chat/application/chat_notifier.dart';
@@ -91,7 +92,7 @@ void main() {
 
       final state = container.read(chatProvider);
 
-      expect(state.messages, isEmpty);
+      check(state.messages).isEmpty();
     });
 
     group('sendMessage (単発送信)', () {
@@ -102,8 +103,8 @@ void main() {
 
         await notifier.sendMessage('   '); // スペースのみ
 
-        expect(container.read(chatProvider).messages, isEmpty);
-        expect(fakeRepo.sendMessageCallCount, 0); // 呼ばれていないこと
+        check(container.read(chatProvider).messages).isEmpty();
+        check(fakeRepo.sendMessageCallCount).equals(0); // 呼ばれていないこと
       });
 
       test('正常系: ユーザーのメッセージとAIの返答がstateに追加されること', () async {
@@ -115,12 +116,12 @@ void main() {
 
         final state = container.read(chatProvider);
 
-        expect(state.messages.length, 2);
-        expect(state.messages.first, isA<ChatMessageUser>());
-        expect(state.messages.first.toString(), contains('こんにちは'));
+        check(state.messages.length).equals(2);
+        check(state.messages.first).isA<ChatMessageUser>();
+        check(state.messages.first.toString()).contains('こんにちは');
 
-        expect(state.messages.last, isA<ChatMessageAi>());
-        expect(state.messages.last.toString(), contains('単発のAI返答'));
+        check(state.messages.last).isA<ChatMessageAi>();
+        check(state.messages.last.toString()).contains('単発のAI返答');
       });
 
       test('排他制御: 生成中に連続で送信しても、2回目以降は無視されること', () async {
@@ -140,9 +141,9 @@ void main() {
         final state = container.read(chatProvider);
 
         // 結果検証: リポジトリは1回しか呼ばれておらず、リストも2つ（1回目の質問と答え）のみ
-        expect(fakeRepo.sendMessageCallCount, 1);
-        expect(state.messages.length, 2);
-        expect(state.messages.first.toString(), contains('1回目'));
+        check(fakeRepo.sendMessageCallCount).equals(1);
+        check(state.messages.length).equals(2);
+        check(state.messages.first.toString()).contains('1回目');
       });
 
       test('異常系: 例外が発生した場合、対象の要素がエラーメッセージに差し替わること', () async {
@@ -154,8 +155,8 @@ void main() {
 
         final state = container.read(chatProvider);
 
-        expect(state.messages.length, 2);
-        expect(state.messages.last, isA<ChatMessageError>());
+        check(state.messages.length).equals(2);
+        check(state.messages.last).isA<ChatMessageError>();
       });
     });
 
@@ -167,8 +168,8 @@ void main() {
 
         await notifier.sendMessageStream('   ');
 
-        expect(container.read(chatProvider).messages, isEmpty);
-        expect(fakeRepo.sendMessageStreamCallCount, 0);
+        check(container.read(chatProvider).messages).isEmpty();
+        check(fakeRepo.sendMessageStreamCallCount).equals(0);
       });
 
       test('正常系: システム日時が付与され、Streamから届くチャンクが結合されていくこと', () async {
@@ -183,13 +184,12 @@ void main() {
         final state = container.read(chatProvider);
 
         // 1. 結合されたメッセージの検証
-        expect(state.messages.length, 2);
-        expect(state.messages.last, isA<ChatMessageAi>());
-        expect(state.messages.last.toString(), contains('AIからの返答です'));
+        check(state.messages.length).equals(2);
+        check(state.messages.last).isA<ChatMessageAi>();
+        check(state.messages.last.toString()).contains('AIからの返答です');
 
         // 2. 日付コンテキスト（システム情報）が正しく Repository に渡されたかの検証
-        expect(
-          fakeRepo.lastStreamText,
+        check(fakeRepo.lastStreamText).equals(
           '[System Information: Current Time is 2026-03-21 10:00]\nストリームテスト',
         );
       });
@@ -202,10 +202,9 @@ void main() {
         // 1回目を await せずに実行
         final future1 = notifier.sendMessageStream('1回目のStream');
 
-        expect(
+        check(
           container.read(chatProvider).isGenerating,
-          isTrue,
-        ); // 生成中になっていること
+        ).equals(true); // 生成中になっていること
 
         // 瞬時に2回目を実行（ブロックされるはず）
         final future2 = notifier.sendMessageStream('2回目のStream');
@@ -215,9 +214,9 @@ void main() {
 
         final state = container.read(chatProvider);
 
-        expect(state.isGenerating, isFalse); // 生成が終わっていること
-        expect(fakeRepo.sendMessageStreamCallCount, 1);
-        expect(state.messages.length, 2);
+        check(state.isGenerating).equals(false); // 生成が終わっていること
+        check(fakeRepo.sendMessageStreamCallCount).equals(1);
+        check(state.messages.length).equals(2);
       });
 
       test(
@@ -231,12 +230,11 @@ void main() {
 
           final state = container.read(chatProvider);
 
-          expect(state.messages.length, 2);
-          expect(state.messages.last, isA<ChatMessageError>());
-          expect(
+          check(state.messages.length).equals(2);
+          check(state.messages.last).isA<ChatMessageError>();
+          check(
             state.messages.last.toString(),
-            contains('ChatEmptyResponseException'),
-          );
+          ).contains('ChatEmptyResponseException');
         },
       );
 
@@ -249,8 +247,8 @@ void main() {
 
         final state = container.read(chatProvider);
 
-        expect(state.messages.length, 2);
-        expect(state.messages.last, isA<ChatMessageError>());
+        check(state.messages.length).equals(2);
+        check(state.messages.last).isA<ChatMessageError>();
       });
     });
 
@@ -261,14 +259,14 @@ void main() {
 
       // まずメッセージを1つ追加
       await notifier.sendMessage('テスト');
-      expect(container.read(chatProvider).messages, isNotEmpty);
+      check(container.read(chatProvider).messages).isNotEmpty();
 
       // クリア実行
       notifier.clearHistory();
 
       final state = container.read(chatProvider);
-      expect(state.messages, isEmpty);
-      expect(state.isGenerating, isFalse);
+      check(state.messages).isEmpty();
+      check(state.isGenerating).equals(false);
     });
   });
 }

--- a/test/src/features/chat/data/chat_repository_test.dart
+++ b/test/src/features/chat/data/chat_repository_test.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/chat/data/chat_api_client.dart';
 import 'package:flutter_sample/src/features/chat/data/chat_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 
 // --- モッククラスの定義 ---
@@ -30,7 +32,7 @@ void main() {
         final result = await repository.sendMessage('テストプロンプト');
 
         // Assert: 結果を検証
-        expect(result, 'こんにちは！AIです。');
+        check(result).equals('こんにちは！AIです。');
         verify(() => mockApiClient.sendMessage('テストプロンプト')).called(1);
       });
 
@@ -42,10 +44,9 @@ void main() {
           ).thenAnswer((_) async => '');
 
           // 例外が投げられることを検証
-          expect(
-            () => repository.sendMessage('テスト'),
-            throwsA(isA<ChatEmptyResponseException>()),
-          );
+          await check(
+            repository.sendMessage('テスト'),
+          ).throws<ChatEmptyResponseException>();
         },
       );
 
@@ -55,10 +56,9 @@ void main() {
         ).thenAnswer((_) async => null);
 
         // nullの場合も同様に例外になることを検証
-        expect(
-          () => repository.sendMessage('テスト'),
-          throwsA(isA<ChatEmptyResponseException>()),
-        );
+        await check(
+          repository.sendMessage('テスト'),
+        ).throws<ChatEmptyResponseException>();
       });
     });
 
@@ -74,8 +74,7 @@ void main() {
 
         // Assert: Streamから流れてくる値を順番に検証
         // .map((text) => text ?? '') のロジックによって、nullが空文字に変換されることを確認
-        expect(
-          stream,
+        check(stream).legacyMatcher(
           emitsInOrder([
             'AI',
             '', // null が 空文字('') に変換されていること！

--- a/test/src/features/chat/domain/chat_message_test.dart
+++ b/test/src/features/chat/domain/chat_message_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/chat/domain/chat_message.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -14,13 +15,13 @@ void main() {
       );
 
       // 1. プロパティの保持確認
-      expect(message.id, 'user_1');
-      expect(message.createdAt, dummyTime);
+      check(message.id).equals('user_1');
+      check(message.createdAt).equals(dummyTime);
 
       // 2. カスタムゲッターの検証
-      expect(message.isUser, isTrue);
-      expect(message.isAi, isFalse);
-      expect(message.displayText, 'こんにちは');
+      check(message.isUser).equals(true);
+      check(message.isAi).equals(false);
+      check(message.displayText).equals('こんにちは');
     });
 
     test('ai: プロパティとカスタムゲッターが正しく機能すること', () {
@@ -30,12 +31,12 @@ void main() {
         createdAt: dummyTime,
       );
 
-      expect(message.id, 'ai_1');
-      expect(message.createdAt, dummyTime);
+      check(message.id).equals('ai_1');
+      check(message.createdAt).equals(dummyTime);
 
-      expect(message.isUser, isFalse);
-      expect(message.isAi, isTrue);
-      expect(message.displayText, 'AIの返答です');
+      check(message.isUser).equals(false);
+      check(message.isAi).equals(true);
+      check(message.displayText).equals('AIの返答です');
     });
 
     test('loading: プロパティとカスタムゲッターが正しく機能すること', () {
@@ -44,13 +45,13 @@ void main() {
         createdAt: dummyTime,
       );
 
-      expect(message.id, 'loading_1');
-      expect(message.createdAt, dummyTime);
+      check(message.id).equals('loading_1');
+      check(message.createdAt).equals(dummyTime);
 
       // loading はどちらでもなく、表示すべきテキストもない
-      expect(message.isUser, isFalse);
-      expect(message.isAi, isFalse);
-      expect(message.displayText, isNull);
+      check(message.isUser).equals(false);
+      check(message.isAi).equals(false);
+      check(message.displayText).isNull();
     });
 
     test('error: プロパティとカスタムゲッターが正しく機能すること', () {
@@ -61,15 +62,15 @@ void main() {
         createdAt: dummyTime,
       );
 
-      expect(message.id, 'error_1');
-      expect(message.createdAt, dummyTime);
+      check(message.id).equals('error_1');
+      check(message.createdAt).equals(dummyTime);
 
       // error プロパティに正しくアクセスできるか（キャストして検証）
-      expect((message as ChatMessageError).error, exception);
+      check((message as ChatMessageError).error).equals(exception);
 
-      expect(message.isUser, isFalse);
-      expect(message.isAi, isFalse);
-      expect(message.displayText, isNull);
+      check(message.isUser).equals(false);
+      check(message.isAi).equals(false);
+      check(message.displayText).isNull();
     });
 
     test('同値性(Equatable): 同じ値を持つインスタンスは等価と判定されること', () {
@@ -90,8 +91,8 @@ void main() {
         createdAt: dummyTime,
       );
 
-      expect(message1, equals(message2));
-      expect(message1, isNot(equals(message3)));
+      check(message1).equals(message2);
+      check(message1).not((it) => it.equals(message3));
     });
   });
 }

--- a/test/src/features/chat/presentation/chat_bubble_shimmer_test.dart
+++ b/test/src/features/chat/presentation/chat_bubble_shimmer_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/src/features/chat/presentation/chat_bubble_shimmer.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shimmer/shimmer.dart';
@@ -16,11 +18,11 @@ void main() {
       );
 
       // 2. キラキラ効果（Shimmer）が吹き出し部分と時間表示部分の2箇所に表示されていることを確認します
-      expect(find.byType(Shimmer), findsNWidgets(2));
+      check(find.byType(Shimmer)).findsExactly(2);
 
       // 3. 吹き出しやダミーテキストを模した四角いコンテナ（Container）が描画されていることを確認します
       // 吹き出し外枠 + テキスト1行目 + テキスト2行目 + 時間 のため、複数存在します
-      expect(find.byType(Container), findsAtLeastNWidgets(3));
+      check(find.byType(Container)).findsAtLeast(3);
     });
 
     testWidgets('ダークモードで骨組み（Shimmer）と吹き出しボックスが正しく描画されること', (tester) async {
@@ -35,8 +37,8 @@ void main() {
       );
 
       // 2. ダークモードでも同様にShimmerが2箇所表示されていることを確認します
-      expect(find.byType(Shimmer), findsNWidgets(2));
-      expect(find.byType(Container), findsAtLeastNWidgets(3));
+      check(find.byType(Shimmer)).findsExactly(2);
+      check(find.byType(Container)).findsAtLeast(3);
     });
   });
 }

--- a/test/src/features/chat/presentation/chat_screen_test.dart
+++ b/test/src/features/chat/presentation/chat_screen_test.dart
@@ -1,6 +1,8 @@
 // ignore_for_file: document_ignores, use_setters_to_change_properties
 
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/utils/connectivity_provider.dart';
@@ -122,28 +124,27 @@ void main() {
           matching: find.byType(IconButton),
         ),
       );
-      expect(sendButton.onPressed, isNull);
+      check(sendButton.onPressed).isNull();
 
       final circleAvatar = tester.widget<CircleAvatar>(
         find.byType(CircleAvatar),
       );
       // オフライン時は colorScheme.outline になるはず
-      expect(
+      check(
         circleAvatar.backgroundColor,
-        ThemeData(useMaterial3: true).colorScheme.outline,
-      );
+      ).equals(ThemeData(useMaterial3: true).colorScheme.outline);
 
       final textField = tester.widget<TextField>(find.byType(TextField));
-      expect(textField.enabled, isTrue); // テキスト入力は可能なはず
+      check(textField.enabled).equals(true); // テキスト入力は可能なはず
     });
 
     testWidgets('初期表示: タイトルと入力フォームが表示され、メッセージリストは空であること', (tester) async {
       await setupWidget(tester);
 
-      expect(find.text('チャット'), findsOneWidget);
-      expect(find.byType(TextField), findsOneWidget);
-      expect(find.byType(ListView), findsOneWidget);
-      expect(find.byIcon(Icons.delete_sweep_outlined), findsOneWidget);
+      check(find.text('チャット')).findsOne();
+      check(find.byType(TextField)).findsOne();
+      check(find.byType(ListView)).findsOne();
+      check(find.byIcon(Icons.delete_sweep_outlined)).findsOne();
     });
 
     testWidgets('メッセージ描画: ユーザーとAIのメッセージが正しく表示されること', (tester) async {
@@ -159,9 +160,9 @@ void main() {
       await setupWidget(tester, notifier: notifier);
       await tester.pumpAndSettle();
 
-      expect(find.text('Hello'), findsOneWidget);
-      expect(find.text('Hi there!'), findsOneWidget);
-      expect(find.text('10:30'), findsNWidgets(2));
+      check(find.text('Hello')).findsOne();
+      check(find.text('Hi there!')).findsOne();
+      check(find.text('10:30')).findsExactly(2);
     });
 
     testWidgets('メッセージ描画: ローディングメッセージが正しく表示されること', (tester) async {
@@ -173,7 +174,7 @@ void main() {
       final notifier = FakeChatNotifier(state);
 
       await setupWidget(tester, notifier: notifier);
-      expect(find.byType(ChatBubbleShimmer), findsOneWidget);
+      check(find.byType(ChatBubbleShimmer)).findsOne();
     });
 
     testWidgets(
@@ -185,8 +186,8 @@ void main() {
         await setupWidget(tester, notifier: notifier);
 
         final textField = tester.widget<TextField>(find.byType(TextField));
-        expect(textField.enabled, isFalse);
-        expect(find.text('考え中...'), findsOneWidget);
+        check(textField.enabled).equals(false);
+        check(find.text('考え中...')).findsOne();
 
         final sendButton = tester.widget<IconButton>(
           find.descendant(
@@ -194,7 +195,7 @@ void main() {
             matching: find.byType(IconButton),
           ),
         );
-        expect(sendButton.onPressed, isNull);
+        check(sendButton.onPressed).isNull();
       },
     );
 
@@ -208,9 +209,9 @@ void main() {
       await tester.tap(find.byIcon(Icons.send));
       await tester.pump();
 
-      expect(notifier.lastSentText, 'Test Message');
+      check(notifier.lastSentText).equals('Test Message');
       final textField = tester.widget<TextField>(find.byType(TextField));
-      expect(textField.controller?.text, isEmpty);
+      check(textField.controller?.text).isNotNull().isEmpty();
     });
 
     testWidgets('全削除ボタン: キャンセルした場合は何も起きないこと', (tester) async {
@@ -223,7 +224,7 @@ void main() {
       await tester.tap(find.widgetWithText(TextButton, '閉じる'));
       await tester.pumpAndSettle();
 
-      expect(notifier.clearHistoryCalled, isFalse);
+      check(notifier.clearHistoryCalled).equals(false);
     });
 
     testWidgets('全削除ボタン: 「すべて削除」を選択すると履歴がクリアされること', (tester) async {
@@ -240,7 +241,7 @@ void main() {
       await tester.tap(confirmButton);
       await tester.pumpAndSettle();
 
-      expect(notifier.clearHistoryCalled, isTrue);
+      check(notifier.clearHistoryCalled).equals(true);
     });
 
     testWidgets('メッセージ描画: エラーメッセージが正しく表示されること', (tester) async {
@@ -259,7 +260,7 @@ void main() {
       await setupWidget(tester, notifier: notifier);
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('エラー発生'), findsOneWidget);
+      check(find.textContaining('エラー発生')).findsOne();
     });
 
     testWidgets('メッセージ描画: 空の返答エラーが正しく表示されること', (tester) async {
@@ -278,7 +279,7 @@ void main() {
       await setupWidget(tester, notifier: notifier);
       await tester.pumpAndSettle();
 
-      expect(find.text('空の返答'), findsOneWidget);
+      check(find.text('空の返答')).findsOne();
     });
 
     testWidgets('オートスクロール: メッセージが増えた時にスクロールされること', (tester) async {
@@ -311,7 +312,7 @@ void main() {
       await tester.enterText(find.byType(TextField), '   ');
       await tester.testTextInput.receiveAction(TextInputAction.send);
       await tester.pump();
-      expect(notifier.lastSentText, isNull);
+      check(notifier.lastSentText).isNull();
     });
 
     testWidgets('画面外タップでキーボードが閉じること', (tester) async {
@@ -323,13 +324,13 @@ void main() {
       await tester.pumpAndSettle();
 
       final BuildContext context = tester.element(textFields.first);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // AppBarなど画面外をタップ
       await tester.tap(find.byType(AppBar));
       await tester.pumpAndSettle();
 
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
     });
   });
 }

--- a/test/src/features/home/presentation/home_screen_test.dart
+++ b/test/src/features/home/presentation/home_screen_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/analytics/analytics_event.dart';
@@ -205,9 +207,9 @@ void main() {
       await setupWidget(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('ホーム'), findsOneWidget);
-      expect(find.text('現在の環境'), findsOneWidget);
-      expect(find.text('LOCAL'), findsOneWidget);
+      check(find.text('ホーム')).findsOne();
+      check(find.text('現在の環境')).findsOne();
+      check(find.text('LOCAL')).findsOne();
     });
 
     testWidgets('アップデート通知: 新しいバージョンがある場合にダイアログが表示されること', (tester) async {
@@ -218,12 +220,12 @@ void main() {
       controller.emit(UpdateRequestType.cancelable);
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsOneWidget);
-      expect(find.text('アップデート'), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
+      check(find.text('アップデート')).findsOne();
 
       await tester.tap(find.text('後で'));
       await tester.pumpAndSettle();
-      expect(find.byType(AlertDialog), findsNothing);
+      check(find.byType(AlertDialog)).findsNothing();
     });
 
     testWidgets('アップデート通知: 強制アップデートの場合に「後で」ボタンがないこと', (tester) async {
@@ -234,8 +236,8 @@ void main() {
       controller.emit(UpdateRequestType.forcibly);
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsOneWidget);
-      expect(find.text('後で'), findsNothing);
+      check(find.byType(AlertDialog)).findsOne();
+      check(find.text('後で')).findsNothing();
 
       when(() => mockTalker.info(any<dynamic>())).thenReturn(null);
       await tester.tap(find.text('更新'));
@@ -255,7 +257,7 @@ void main() {
       controller.emit(UpdateRequestType.cancelable);
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsNothing);
+      check(find.byType(AlertDialog)).findsNothing();
     });
 
     testWidgets('エラー表示: アップデート情報の取得に失敗した場合でもアプリ情報取得が動作すること', (
@@ -277,18 +279,18 @@ void main() {
       await tester.tap(buttonFinder);
       await tester.pumpAndSettle();
 
-      expect(find.text('テストアプリ'), findsOneWidget);
+      check(find.text('テストアプリ')).findsOne();
     });
 
     testWidgets('ローディング状態: インジケータが表示されること', (tester) async {
       final controller = FakeUpdateRequestController(startLoading: true);
       await setupWidget(tester, controller: controller);
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      check(find.byType(CircularProgressIndicator)).findsOne();
 
       controller.complete(UpdateRequestType.not);
       await tester.pumpAndSettle();
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      check(find.byType(CircularProgressIndicator)).findsNothing();
     });
 
     testWidgets('PackageInfo: アプリ情報取得ボタンを押すと、情報が読み込まれてUIが更新されること', (
@@ -306,8 +308,8 @@ void main() {
       await tester.tap(buttonFinder);
       await tester.pumpAndSettle();
 
-      expect(find.text('テストアプリ'), findsOneWidget);
-      expect(find.text('com.example.testapp'), findsOneWidget);
+      check(find.text('テストアプリ')).findsOne();
+      check(find.text('com.example.testapp')).findsOne();
     });
 
     testWidgets('開発者ログ: ボタンを押すとTalkerScreenへ遷移すること', (tester) async {
@@ -330,7 +332,7 @@ void main() {
       await tester.tap(menuBtn);
       await tester.pumpAndSettle();
 
-      expect(find.byType(TalkerScreen), findsOneWidget);
+      check(find.byType(TalkerScreen)).findsOne();
     });
 
     testWidgets('Crashlytics: クラッシュテストボタンを押すと、crash メソッドが呼ばれること', (
@@ -411,7 +413,7 @@ void main() {
       await setupWidget(tester, flavor: Flavor.prod);
       await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(ListTile, '開発者ログ'), findsNothing);
+      check(find.widgetWithText(ListTile, '開発者ログ')).findsNothing();
     });
   });
 
@@ -427,7 +429,7 @@ void main() {
       );
       await tester.tap(finder);
       await tester.pumpAndSettle();
-      expect(attemptedPath, contains('undefined'));
+      check(attemptedPath).isNotNull().contains('undefined');
     });
 
     testWidgets('AppBarの設定アイコンから設定画面へ遷移すること', (tester) async {
@@ -437,7 +439,7 @@ void main() {
       await tester.tap(find.byIcon(Icons.settings_outlined));
       await tester.pumpAndSettle();
 
-      expect(attemptedPath, contains('settings'));
+      check(attemptedPath).isNotNull().contains('settings');
     });
   });
 }

--- a/test/src/features/memos/application/memo_notifier_test.dart
+++ b/test/src/features/memos/application/memo_notifier_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/memos/application/memo_notifier.dart';
 import 'package:flutter_sample/src/features/memos/data/memo_repository.dart';
 import 'package:flutter_sample/src/features/memos/domain/memo_model.dart';
@@ -45,7 +46,7 @@ void main() {
 
       final memos = await container.read(memoProvider.future);
 
-      expect(memos, mockMemos);
+      check(memos).deepEquals(mockMemos);
       verify(() => mockMemoRepository.getAllMemos()).called(1);
 
       subscription.close();
@@ -131,8 +132,8 @@ void main() {
       }
 
       final state = container.read(memoProvider);
-      expect(state.hasError, isTrue);
-      expect(state.error, exception);
+      check(state.hasError).equals(true);
+      check(state.error).equals(exception);
 
       subscription.close();
     });
@@ -173,18 +174,18 @@ void main() {
         final memoSub = container.listen(memoProvider, (_, _) {});
 
         var memos = await container.read(memoProvider.future);
-        expect(memos.length, 3);
+        check(memos.length).equals(3);
 
         container.read(memoSearchQueryProvider.notifier).setQuery(' BANANA ');
         memos = await container.read(memoProvider.future);
-        expect(memos.length, 1);
-        expect(memos.first.id, '2');
+        check(memos.length).equals(1);
+        check(memos.first.id).equals('2');
 
         container.read(memoSearchQueryProvider.notifier).setQuery('juice');
         memos = await container.read(memoProvider.future);
-        expect(memos.length, 2);
-        expect(memos.any((m) => m.id == '2'), isTrue);
-        expect(memos.any((m) => m.id == '3'), isTrue);
+        check(memos.length).equals(2);
+        check(memos.any((m) => m.id == '2')).equals(true);
+        check(memos.any((m) => m.id == '3')).equals(true);
 
         querySub.close();
         memoSub.close();
@@ -201,31 +202,31 @@ void main() {
             .read(memoSortOrderStateProvider.notifier)
             .setSortOrder(MemoSortOrder.createdAtAsc);
         var memos = await container.read(memoProvider.future);
-        expect(memos.map((m) => m.id).toList(), ['3', '1', '2']);
+        check(memos.map((m) => m.id).toList()).deepEquals(['3', '1', '2']);
 
         container
             .read(memoSortOrderStateProvider.notifier)
             .setSortOrder(MemoSortOrder.updatedAtDesc);
         memos = await container.read(memoProvider.future);
-        expect(memos.map((m) => m.id).toList(), ['3', '1', '2']);
+        check(memos.map((m) => m.id).toList()).deepEquals(['3', '1', '2']);
 
         container
             .read(memoSortOrderStateProvider.notifier)
             .setSortOrder(MemoSortOrder.updatedAtAsc);
         memos = await container.read(memoProvider.future);
-        expect(memos.map((m) => m.id).toList(), ['2', '1', '3']);
+        check(memos.map((m) => m.id).toList()).deepEquals(['2', '1', '3']);
 
         container
             .read(memoSortOrderStateProvider.notifier)
             .setSortOrder(MemoSortOrder.titleAsc);
         memos = await container.read(memoProvider.future);
-        expect(memos.map((m) => m.id).toList(), ['1', '2', '3']);
+        check(memos.map((m) => m.id).toList()).deepEquals(['1', '2', '3']);
 
         container
             .read(memoSortOrderStateProvider.notifier)
             .setSortOrder(MemoSortOrder.titleDesc);
         memos = await container.read(memoProvider.future);
-        expect(memos.map((m) => m.id).toList(), ['3', '2', '1']);
+        check(memos.map((m) => m.id).toList()).deepEquals(['3', '2', '1']);
 
         sortSub.close();
         memoSub.close();

--- a/test/src/features/memos/data/memo_remote_service_test.dart
+++ b/test/src/features/memos/data/memo_remote_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/memos/data/memo_remote_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -12,7 +13,7 @@ void main() {
 
     test('初期状態ではfetchMemosは空のリストを返すこと', () async {
       final result = await service.fetchMemos();
-      expect(result, isEmpty);
+      check(result).isNotNull().isEmpty();
     });
 
     test('uploadMemoで新しいメモを追加し、fetchMemosで取得できること', () async {
@@ -28,13 +29,13 @@ void main() {
       );
 
       final result = await service.fetchMemos();
-      expect(result.length, 1);
-      expect(result.first['id'], 'memo1');
-      expect(result.first['title'], 'テストタイトル');
-      expect(result.first['content'], 'テストコンテンツ');
-      expect(result.first['createdAt'], now);
-      expect(result.first['updatedAt'], now);
-      expect(result.first['isDeleted'], false);
+      check(result.length).equals(1);
+      check(result.first['id']).equals('memo1');
+      check(result.first['title']).equals('テストタイトル');
+      check(result.first['content']).equals('テストコンテンツ');
+      check(result.first['createdAt']).equals(now);
+      check(result.first['updatedAt']).equals(now);
+      check(result.first['isDeleted']).equals(false);
     });
 
     test('uploadMemoで既存のメモを更新できること', () async {
@@ -62,13 +63,13 @@ void main() {
       );
 
       final result = await service.fetchMemos();
-      expect(result.length, 1); // 追加されず上書きされていること
-      expect(result.first['id'], 'memo1');
-      expect(result.first['title'], '新しいタイトル');
-      expect(result.first['content'], '新しいコンテンツ');
-      expect(result.first['createdAt'], now);
-      expect(result.first['updatedAt'], updatedTime);
-      expect(result.first['isDeleted'], true);
+      check(result.length).equals(1); // 追加されず上書きされていること
+      check(result.first['id']).equals('memo1');
+      check(result.first['title']).equals('新しいタイトル');
+      check(result.first['content']).equals('新しいコンテンツ');
+      check(result.first['createdAt']).equals(now);
+      check(result.first['updatedAt']).equals(updatedTime);
+      check(result.first['isDeleted']).equals(true);
     });
   });
 
@@ -78,7 +79,7 @@ void main() {
       addTearDown(container.dispose);
 
       final service = container.read(memoRemoteServiceProvider);
-      expect(service, isA<MemoRemoteService>());
+      check(service).isA<MemoRemoteService>();
     });
   });
 }

--- a/test/src/features/memos/data/memo_repository_test.dart
+++ b/test/src/features/memos/data/memo_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:drift/drift.dart' as drift;
 import 'package:drift/native.dart';
 import 'package:flutter_sample/src/app/database/app_database.dart';
@@ -72,9 +73,9 @@ void main() {
       await repository.addMemo('title', 'content');
 
       final memos = await database.select(database.memos).get();
-      expect(memos.length, 1);
-      expect(memos.first.title, 'title');
-      expect(memos.first.isSynced, false);
+      check(memos.length).equals(1);
+      check(memos.first.title).equals('title');
+      check(memos.first.isSynced).equals(false);
       verifyNever(
         () => mockRemoteService.uploadMemo(
           id: any(named: 'id'),
@@ -94,9 +95,9 @@ void main() {
       await repository.addMemo('title', 'content');
 
       final memos = await database.select(database.memos).get();
-      expect(memos.length, 1);
-      expect(memos.first.title, 'title');
-      expect(memos.first.isSynced, true);
+      check(memos.length).equals(1);
+      check(memos.first.title).equals('title');
+      check(memos.first.isSynced).equals(true);
       verify(
         () => mockRemoteService.uploadMemo(
           id: memos.first.id,
@@ -126,7 +127,7 @@ void main() {
       await repository.addMemo('title', 'content');
 
       final memos = await database.select(database.memos).get();
-      expect(memos.first.isSynced, false);
+      check(memos.first.isSynced).equals(false);
     });
 
     test('updateMemo: オフラインの場合、ローカルが更新され isSynced が false になること', () async {
@@ -150,8 +151,8 @@ void main() {
       final memo = await (database.select(
         database.memos,
       )..where((m) => m.id.equals('id1'))).getSingle();
-      expect(memo.title, 'new title');
-      expect(memo.isSynced, false);
+      check(memo.title).equals('new title');
+      check(memo.isSynced).equals(false);
       verifyNever(
         () => mockRemoteService.uploadMemo(
           id: any(named: 'id'),
@@ -184,7 +185,7 @@ void main() {
       final memo = await (database.select(
         database.memos,
       )..where((m) => m.id.equals('id1'))).getSingle();
-      expect(memo.isSynced, true);
+      check(memo.isSynced).equals(true);
       verify(
         () => mockRemoteService.uploadMemo(
           id: 'id1',
@@ -227,7 +228,7 @@ void main() {
       final memo = await (database.select(
         database.memos,
       )..where((m) => m.id.equals('id1'))).getSingle();
-      expect(memo.isSynced, false);
+      check(memo.isSynced).equals(false);
     });
 
     test('deleteMemo: オフラインの場合、ローカルで論理削除され isSynced が false になること', () async {
@@ -251,8 +252,8 @@ void main() {
       final memo = await (database.select(
         database.memos,
       )..where((m) => m.id.equals('id1'))).getSingle();
-      expect(memo.isDeleted, true);
-      expect(memo.isSynced, false);
+      check(memo.isDeleted).equals(true);
+      check(memo.isSynced).equals(false);
       verifyNever(
         () => mockRemoteService.uploadMemo(
           id: any(named: 'id'),
@@ -287,8 +288,8 @@ void main() {
         final memo = await (database.select(
           database.memos,
         )..where((m) => m.id.equals('id1'))).getSingle();
-        expect(memo.isDeleted, true);
-        expect(memo.isSynced, true);
+        check(memo.isDeleted).equals(true);
+        check(memo.isSynced).equals(true);
       },
     );
 
@@ -322,8 +323,8 @@ void main() {
       final memo = await (database.select(
         database.memos,
       )..where((m) => m.id.equals('id1'))).getSingle();
-      expect(memo.isDeleted, true);
-      expect(memo.isSynced, false);
+      check(memo.isDeleted).equals(true);
+      check(memo.isSynced).equals(false);
     });
 
     test('syncUnsentMemos: 未送信のメモがない場合、何もしないこと', () async {
@@ -375,7 +376,7 @@ void main() {
       final memo1 = await (database.select(
         database.memos,
       )..where((m) => m.id.equals('1'))).getSingle();
-      expect(memo1.isSynced, true);
+      check(memo1.isSynced).equals(true);
       verify(
         () => mockRemoteService.uploadMemo(
           id: '1',
@@ -429,8 +430,8 @@ void main() {
       await repository.syncUnsentMemos();
 
       final memos = await database.select(database.memos).get();
-      expect(memos.firstWhere((m) => m.id == '1').isSynced, false);
-      expect(memos.firstWhere((m) => m.id == '2').isSynced, true);
+      check(memos.firstWhere((m) => m.id == '1').isSynced).equals(false);
+      check(memos.firstWhere((m) => m.id == '2').isSynced).equals(true);
       verify(
         () => mockRemoteService.uploadMemo(
           id: '2',
@@ -473,8 +474,8 @@ void main() {
 
       final memos = await repository.getAllMemos();
 
-      expect(memos.length, 1);
-      expect(memos.first.id, '1');
+      check(memos.length).equals(1);
+      check(memos.first.id).equals('1');
       // オフラインでも fetchMemos は呼ばれる実装になっている
       verify(() => mockRemoteService.fetchMemos()).called(1);
     });
@@ -497,9 +498,9 @@ void main() {
 
       final memos = await repository.getAllMemos();
 
-      expect(memos.length, 1);
-      expect(memos.first.id, 'remote1');
-      expect(memos.first.title, 'rtitle');
+      check(memos.length).equals(1);
+      check(memos.first.id).equals('remote1');
+      check(memos.first.title).equals('rtitle');
     });
 
     test(
@@ -535,8 +536,8 @@ void main() {
 
         final memos = await repository.getAllMemos();
 
-        expect(memos.length, 1);
-        expect(memos.first.title, 'remote');
+        check(memos.length).equals(1);
+        check(memos.first.title).equals('remote');
       },
     );
 
@@ -573,8 +574,8 @@ void main() {
 
         final memos = await repository.getAllMemos();
 
-        expect(memos.length, 1);
-        expect(memos.first.title, 'local');
+        check(memos.length).equals(1);
+        check(memos.first.title).equals('local');
       },
     );
 
@@ -587,13 +588,13 @@ void main() {
 
       final memos = await repository.getAllMemos();
 
-      expect(memos.length, 0); // local is empty
+      check(memos.length).equals(0); // local is empty
     });
 
     test('memoRepositoryProvider が正しいインスタンスを提供すること', () {
       final container = createContainer();
       final repo = container.read(memoRepositoryProvider);
-      expect(repo, isA<MemoRepository>());
+      check(repo).isA<MemoRepository>();
     });
   });
 }

--- a/test/src/features/memos/domain/memo_model_test.dart
+++ b/test/src/features/memos/domain/memo_model_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/memos/domain/memo_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -13,10 +14,10 @@ void main() {
         updatedAt: now,
       );
 
-      expect(memo.id, '1');
-      expect(memo.title, 'テスト');
-      expect(memo.content, '内容');
-      expect(memo.createdAt, now);
+      check(memo.id).equals('1');
+      check(memo.title).equals('テスト');
+      check(memo.content).equals('内容');
+      check(memo.createdAt).equals(now);
     });
 
     test('同じ値を持つインスタンスは等価と判定されること (Equatable)', () {
@@ -36,8 +37,8 @@ void main() {
         updatedAt: now,
       );
 
-      expect(memo1, memo2);
-      expect(memo1.hashCode, memo2.hashCode);
+      check(memo1).equals(memo2);
+      check(memo1.hashCode).equals(memo2.hashCode);
     });
   });
 }

--- a/test/src/features/memos/presentation/memo_list_shimmer_test.dart
+++ b/test/src/features/memos/presentation/memo_list_shimmer_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_sample/src/features/memos/presentation/memo_list_shimmer.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shimmer/shimmer.dart';
@@ -28,10 +30,10 @@ void main() {
 
       // 3. 画面の高さ（600px）÷ カードの高さ（100px）＝ 6 枚 のカードが表示されているはずです
       // MemoCardShimmer がちょうど6枚あるか確認します
-      expect(find.byType(MemoCardShimmer), findsNWidgets(6));
+      check(find.byType(MemoCardShimmer)).findsExactly(6);
 
       // 4. キラキラ効果（Shimmer）が使われていることを確認します
-      expect(find.byType(Shimmer), findsAtLeastNWidgets(1));
+      check(find.byType(Shimmer)).findsAtLeast(1);
     });
 
     testWidgets('ダークモードでもエラーなく骨組みカードが描画されること', (tester) async {
@@ -45,7 +47,7 @@ void main() {
       );
 
       // ダークモードでも骨組みカードが1枚以上表示されていることを確認します
-      expect(find.byType(MemoCardShimmer), findsAtLeastNWidgets(1));
+      check(find.byType(MemoCardShimmer)).findsAtLeast(1);
     });
   });
 }

--- a/test/src/features/memos/presentation/memo_screen_test.dart
+++ b/test/src/features/memos/presentation/memo_screen_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors, document_ignores
 import 'dart:async';
 
 import 'package:checks/checks.dart';
@@ -81,7 +82,7 @@ void main() {
             GlobalWidgetsLocalizations.delegate,
             GlobalCupertinoLocalizations.delegate,
           ],
-          home: const MemoScreen(),
+          home: MemoScreen(),
         ),
       ),
     );
@@ -414,7 +415,7 @@ void main() {
               GlobalWidgetsLocalizations.delegate,
               GlobalCupertinoLocalizations.delegate,
             ],
-            home: const MemoScreen(),
+            home: MemoScreen(),
           ),
         ),
       );

--- a/test/src/features/memos/presentation/memo_screen_test.dart
+++ b/test/src/features/memos/presentation/memo_screen_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/memos/application/memo_notifier.dart';
@@ -95,7 +97,7 @@ void main() {
 
       await setupWidget(tester);
 
-      expect(find.byType(MemoListShimmer), findsOneWidget);
+      check(find.byType(MemoListShimmer)).findsOne();
     });
 
     testWidgets('エラー状態が正しく表示されること', (tester) async {
@@ -106,7 +108,7 @@ void main() {
       await setupWidget(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('エラーが発生しました'), findsOneWidget);
+      check(find.text('エラーが発生しました')).findsOne();
     });
 
     testWidgets('データが空の場合、空の状態が表示されること', (tester) async {
@@ -115,8 +117,8 @@ void main() {
       await setupWidget(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('メモがありません'), findsOneWidget);
-      expect(find.byIcon(Icons.note_alt_outlined), findsOneWidget);
+      check(find.text('メモがありません')).findsOne();
+      check(find.byIcon(Icons.note_alt_outlined)).findsOne();
     });
 
     testWidgets('データが存在する場合、カードリストとして表示されること', (tester) async {
@@ -138,10 +140,10 @@ void main() {
       await setupWidget(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('タイトル1'), findsOneWidget);
-      expect(find.text('内容1'), findsOneWidget);
-      expect(find.text('同期済み'), findsOneWidget);
-      expect(find.byIcon(Icons.cloud_done), findsOneWidget);
+      check(find.text('タイトル1')).findsOne();
+      check(find.text('内容1')).findsOne();
+      check(find.text('同期済み')).findsOne();
+      check(find.byIcon(Icons.cloud_done)).findsOne();
     });
 
     testWidgets('FABを押すとボトムシートが開き、メモを追加できること', (tester) async {
@@ -158,7 +160,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // ボトムシートが表示されていることを確認（検索バー + タイトル + 内容の3つ）
-      expect(find.byType(TextField), findsNWidgets(3));
+      check(find.byType(TextField)).findsExactly(3);
 
       await tester.enterText(find.widgetWithText(TextField, 'タイトル'), '新タイトル');
       await tester.enterText(find.widgetWithText(TextField, '内容'), '新内容');
@@ -169,7 +171,7 @@ void main() {
 
       verify(() => mockMemoRepository.addMemo('新タイトル', '新内容')).called(1);
       // ボトムシートが閉じていることを確認（検索バーだけが残っている）
-      expect(find.byType(TextField), findsOneWidget);
+      check(find.byType(TextField)).findsOne();
     });
 
     testWidgets('削除ボタンを押すとダイアログが表示され、キャンセルすると何も起きないこと', (tester) async {
@@ -191,13 +193,13 @@ void main() {
       await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
 
       // 「閉じる」ボタンをタップしてキャンセル
       await tester.tap(find.widgetWithText(TextButton, '閉じる'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsNothing);
+      check(find.byType(AlertDialog)).findsNothing();
       verifyNever(() => mockMemoRepository.deleteMemo(any()));
     });
 
@@ -222,7 +224,7 @@ void main() {
       await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlertDialog), findsOneWidget);
+      check(find.byType(AlertDialog)).findsOne();
 
       // 「削除」ボタンをタップ
       await tester.tap(find.widgetWithText(TextButton, '削除'));
@@ -290,24 +292,24 @@ void main() {
       await tester.pumpAndSettle();
 
       // 初期状態では両方表示されている
-      expect(find.text('りんごのメモ'), findsOneWidget);
-      expect(find.text('バナナのメモ'), findsOneWidget);
+      check(find.text('りんごのメモ')).findsOne();
+      check(find.text('バナナのメモ')).findsOne();
 
       // 検索バーに「りんご」を入力
       await tester.enterText(find.byType(TextField).first, 'りんご');
       await tester.pumpAndSettle();
 
       // 「りんご」のみ表示され、「バナナ」は非表示になる
-      expect(find.text('りんごのメモ'), findsOneWidget);
-      expect(find.text('バナナのメモ'), findsNothing);
+      check(find.text('りんごのメモ')).findsOne();
+      check(find.text('バナナのメモ')).findsNothing();
 
       // クリアボタンをタップして検索をリセット
       await tester.tap(find.byIcon(Icons.clear));
       await tester.pumpAndSettle();
 
       // 再び両方表示される
-      expect(find.text('りんごのメモ'), findsOneWidget);
-      expect(find.text('バナナのメモ'), findsOneWidget);
+      check(find.text('りんごのメモ')).findsOne();
+      check(find.text('バナナのメモ')).findsOne();
     });
 
     testWidgets('ソート順を切り替えた際、指定したルールに従ってリストが並び替わること', (tester) async {
@@ -339,7 +341,7 @@ void main() {
       // デフォルトは「作成日時：新しい順」(A_Memoの方がt2で新しいので上に来るはず)
       var posA = tester.getTopLeft(find.text('A_Memo')).dy;
       var posB = tester.getTopLeft(find.text('B_Memo')).dy;
-      expect(posA < posB, isTrue); // A_Memo の方が Y 座標が小さく、上にある
+      check(posA < posB).equals(true); // A_Memo の方が Y 座標が小さく、上にある
 
       // ソートボタン（PopupMenuButton）をタップ
       await tester.tap(find.byIcon(Icons.sort));
@@ -352,7 +354,7 @@ void main() {
       // B_Memo (t1) の方が古いので上に来るはず
       posA = tester.getTopLeft(find.text('A_Memo')).dy;
       posB = tester.getTopLeft(find.text('B_Memo')).dy;
-      expect(posB < posA, isTrue); // B_Memo の方が上にある
+      check(posB < posA).equals(true); // B_Memo の方が上にある
     });
 
     testWidgets('画面外タップでキーボードが閉じること(一覧画面および追加ボトムシート)', (tester) async {
@@ -366,12 +368,12 @@ void main() {
       await tester.pumpAndSettle();
 
       var context = tester.element(searchField);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // 2. AppBar(画面外)をタップしてフォーカスが外れるか確認
       await tester.tap(find.byType(AppBar));
       await tester.pumpAndSettle();
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
 
       // 3. 追加ボトムシートでのテスト: FABをタップしてボトムシートを開く
       await tester.tap(find.byType(FloatingActionButton));
@@ -383,13 +385,13 @@ void main() {
       await tester.pumpAndSettle();
 
       context = tester.element(titleField);
-      expect(FocusScope.of(context).focusedChild, isNotNull);
+      check(FocusScope.of(context).focusedChild).isNotNull();
 
       // 4. ボトムシート内の余白部分(GestureDetector)をタップしてフォーカスが外れるか確認
       // GestureDetectorを特定するためにボトムシートの要素をタップします
       await tester.tap(find.text('メモを追加').last);
       await tester.pumpAndSettle();
-      expect(FocusScope.of(context).focusedChild, isNull);
+      check(FocusScope.of(context).focusedChild).isNull();
     });
 
     testWidgets('外部から検索クエリが変更された場合に入力欄の文字が同期して更新されること', (tester) async {
@@ -420,17 +422,16 @@ void main() {
 
       // 最初は入力欄は空
       final searchField = find.byType(TextField).first;
-      expect(tester.widget<TextField>(searchField).controller?.text, '');
+      check(tester.widget<TextField>(searchField).controller?.text).equals('');
 
       // 外部(プロバイダー)から検索キーワードを「外部変更キーワード」に変更する
       container.read(memoSearchQueryProvider.notifier).setQuery('外部変更キーワード');
       await tester.pumpAndSettle();
 
       // 入力欄の文字が「外部変更キーワード」に自動で切り替わっていることを確認
-      expect(
+      check(
         tester.widget<TextField>(searchField).controller?.text,
-        '外部変更キーワード',
-      );
+      ).equals('外部変更キーワード');
 
       container.dispose();
     });

--- a/test/src/features/settings/presentation/settings_screen_test.dart
+++ b/test/src/features/settings/presentation/settings_screen_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/config/app_config_provider.dart';
@@ -173,14 +175,13 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      expect(
+      check(
         find.byWidgetPredicate(
           (w) =>
               w is CircularProgressIndicator ||
               w.runtimeType.toString() == 'CupertinoActivityIndicator',
         ),
-        findsOneWidget,
-      );
+      ).findsOne();
     });
 
     testWidgets('エラー状態の時、エラーメッセージが表示されること', (tester) async {
@@ -189,7 +190,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('Config Load Error'), findsOneWidget);
+      check(find.textContaining('Config Load Error')).findsOne();
     });
 
     group('データ取得完了後 (Data状態)', () {
@@ -197,11 +198,11 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        expect(find.text('設定'), findsOneWidget);
-        expect(find.text('テーマ設定'), findsOneWidget);
-        expect(find.text('ライト'), findsOneWidget);
-        expect(find.text('言語設定'), findsOneWidget);
-        expect(find.text('Preview: こんにちは！'), findsOneWidget);
+        check(find.text('設定')).findsOne();
+        check(find.text('テーマ設定')).findsOne();
+        check(find.text('ライト')).findsOne();
+        check(find.text('言語設定')).findsOne();
+        check(find.text('Preview: こんにちは！')).findsOne();
       });
 
       testWidgets('テーマのSegmentedButtonを変更した時、ThemeModeNotifierのsetが呼ばれること', (
@@ -214,7 +215,7 @@ void main() {
         await tester.tap(find.text('ダーク'));
         await tester.pumpAndSettle();
 
-        expect(fakeThemeModeNotifier.calledSetMode, ThemeMode.dark);
+        check(fakeThemeModeNotifier.calledSetMode).equals(ThemeMode.dark);
       });
 
       testWidgets('テーマのSwitchを切り替えた時、toggleLightDarkが呼ばれること', (tester) async {
@@ -224,7 +225,7 @@ void main() {
         await tester.tap(find.byType(SwitchListTile));
         await tester.pumpAndSettle();
 
-        expect(fakeThemeModeNotifier.calledToggle, isTrue);
+        check(fakeThemeModeNotifier.calledToggle).equals(true);
       });
 
       testWidgets('言語のSegmentedButtonを変更した時、LocaleNotifier.setLocaleが呼ばれること', (
@@ -237,7 +238,7 @@ void main() {
         await tester.tap(find.text('English'));
         await tester.pumpAndSettle();
 
-        expect(fakeLocaleNotifier.calledSetLocale, 'en');
+        check(fakeLocaleNotifier.calledSetLocale).equals('en');
       });
 
       group('ログアウトボタン (useAuthの分岐)', () {
@@ -247,7 +248,7 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          expect(find.byKey(const Key('logout_button')), findsNothing);
+          check(find.byKey(const Key('logout_button'))).findsNothing();
         });
 
         testWidgets('useAuth == true でログアウト成功時、signOut処理が呼ばれること', (
@@ -303,8 +304,8 @@ void main() {
 
           verify(() => mockAuthRepo.signOut()).called(1);
 
-          expect(find.textContaining('不明なエラー'), findsOneWidget);
-          expect(find.textContaining('Navigated to'), findsNothing);
+          check(find.textContaining('不明なエラー')).findsOne();
+          check(find.textContaining('Navigated to')).findsNothing();
         });
       });
     });

--- a/test/src/features/splash/presentation/splash_screen_test.dart
+++ b/test/src/features/splash/presentation/splash_screen_test.dart
@@ -1,7 +1,6 @@
-// We need to SplashScreen class without const
-// so that this constructor code execution is counted in test coverage.
-// ignore_for_file: prefer_const_constructors
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_screen.dart';
@@ -37,7 +36,7 @@ void main() {
 
   group('SplashScreenのテスト', () {
     test('コンストラクタでインスタンスが生成できること', () {
-      expect(SplashScreen(), isNotNull);
+      check(const SplashScreen()).isNotNull();
     });
 
     testWidgets('初期表示のテスト: 背景グラデーションとロゴが表示されること', (tester) async {
@@ -66,14 +65,14 @@ void main() {
       await tester.pump();
 
       // Scaffold が表示されていること
-      expect(find.byType(Scaffold), findsOneWidget);
+      check(find.byType(Scaffold)).findsOne();
 
       // SplashLogo が表示されていること
-      expect(find.byType(SplashLogo), findsOneWidget);
+      check(find.byType(SplashLogo)).findsOne();
 
       // ロゴ内のアイコンとテキストが表示されていること
-      expect(find.byIcon(Icons.flutter_dash), findsOneWidget);
-      expect(find.text('Flutter Sample App'), findsOneWidget);
+      check(find.byIcon(Icons.flutter_dash)).findsOne();
+      check(find.text('Flutter Sample App')).findsOne();
     });
 
     testWidgets('2秒経過後に SplashState が完了（true）に更新されること', (tester) async {
@@ -106,15 +105,15 @@ void main() {
       await tester.pump();
 
       // 最初は false であること
-      expect(container.read(splashStateProvider), isFalse);
+      check(container.read(splashStateProvider)).equals(false);
 
       // 1秒経過（まだ false のはず）
       await tester.pump(const Duration(seconds: 1));
-      expect(container.read(splashStateProvider), isFalse);
+      check(container.read(splashStateProvider)).equals(false);
 
       // さらに1.5秒経過（合計2.5秒。2秒を超えたため、完了になる）
       await tester.pump(const Duration(milliseconds: 1500));
-      expect(container.read(splashStateProvider), isTrue);
+      check(container.read(splashStateProvider)).equals(true);
     });
   });
 }

--- a/test/src/features/splash/presentation/splash_state_provider_test.dart
+++ b/test/src/features/splash/presentation/splash_state_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/splash/presentation/splash_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -9,7 +10,7 @@ void main() {
       addTearDown(container.dispose);
 
       final splashState = container.read(splashStateProvider);
-      expect(splashState, isFalse);
+      check(splashState).equals(false);
     });
 
     test('finishSplash() を呼び出すと状態が true に変わること', () {
@@ -17,13 +18,13 @@ void main() {
       addTearDown(container.dispose);
 
       // 初期値を確認
-      expect(container.read(splashStateProvider), isFalse);
+      check(container.read(splashStateProvider)).equals(false);
 
       // 完了を通知
       container.read(splashStateProvider.notifier).finishSplash();
 
       // 変更後の値を確認
-      expect(container.read(splashStateProvider), isTrue);
+      check(container.read(splashStateProvider)).equals(true);
     });
   });
 }

--- a/test/src/features/user/application/user_notifier_test.dart
+++ b/test/src/features/user/application/user_notifier_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/user/application/user_notifier.dart';
 import 'package:flutter_sample/src/features/user/data/user_repository.dart';
 import 'package:flutter_sample/src/features/user/domain/user_model.dart';
@@ -69,12 +70,9 @@ void main() {
 
       // Assert
       final state = container.read(userProvider);
-      expect(
-        state,
-        isA<AsyncData<(List<UserModel>, DateTime?)>>(),
-      );
-      expect(state.value?.$1, dummyUsers);
-      expect(state.value?.$2, dummyTimestamp);
+      check(state).isA<AsyncData<(List<UserModel>, DateTime?)>>();
+      check(state.value?.$1).equals(dummyUsers);
+      check(state.value?.$2).equals(dummyTimestamp);
     });
 
     test('異常系: エラーが発生した場合、エラー状態を保持すること', () async {
@@ -99,8 +97,8 @@ void main() {
 
       // Assert
       final state = container.read(userProvider);
-      expect(state.hasError, isTrue);
-      expect(state.error, exception);
+      check(state.hasError).equals(true);
+      check(state.error).equals(exception);
     });
 
     test('refresh: forceRefresh=true でデータが再取得され、状態が更新されること', () async {
@@ -131,12 +129,9 @@ void main() {
 
       // Assert
       final state = container.read(userProvider);
-      expect(
-        state,
-        isA<AsyncData<(List<UserModel>, DateTime?)>>(),
-      );
-      expect(state.value?.$1, refreshedUsers);
-      expect(state.value?.$2, refreshedTimestamp);
+      check(state).isA<AsyncData<(List<UserModel>, DateTime?)>>();
+      check(state.value?.$1).equals(refreshedUsers);
+      check(state.value?.$2).equals(refreshedTimestamp);
     });
   });
 }

--- a/test/src/features/user/data/user_repository_test.dart
+++ b/test/src/features/user/data/user_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_sample/src/core/network/api_client.dart';
 import 'package:flutter_sample/src/core/storage/cache_manager.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_sample/src/core/utils/logger_provider.dart';
 import 'package:flutter_sample/src/features/user/data/user_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 
@@ -79,9 +81,9 @@ void main() {
       final (users, fetchedAt) = await repository.fetchUsers();
 
       // Assert (検証)
-      expect(users.length, 1);
-      expect(users.first.name, 'Test User 1');
-      expect(fetchedAt, dummyTimestamp);
+      check(users.length).equals(1);
+      check(users.first.name).equals('Test User 1');
+      check(fetchedAt).equals(dummyTimestamp);
 
       // API通信とキャッシュ保存が「絶対に呼ばれていないこと」を確認
       verifyNever(() => mockApi.get<List<dynamic>>(any()));
@@ -99,9 +101,9 @@ void main() {
       final (users, fetchedAt) = await repository.fetchUsers();
 
       // Assert (検証)
-      expect(users.length, 1);
+      check(users.length).equals(1);
       // clock() で設定している 10:00 が返ることを確認
-      expect(fetchedAt, DateTime(2026, 5, 17, 10));
+      check(fetchedAt).equals(DateTime(2026, 5, 17, 10));
     });
 
     test('キャッシュが存在しない場合、APIからデータを取得してキャッシュに保存されること', () async {
@@ -130,9 +132,9 @@ void main() {
       final (users, fetchedAt) = await repository.fetchUsers();
 
       // Assert (検証)
-      expect(users.length, 1);
-      expect(users.first.name, 'Test User 1');
-      expect(fetchedAt, DateTime(2026, 5, 17, 10));
+      check(users.length).equals(1);
+      check(users.first.name).equals('Test User 1');
+      check(fetchedAt).equals(DateTime(2026, 5, 17, 10));
 
       // API通信が1回呼ばれ、取得したデータがキャッシュに1回保存されていることを確認
       verify(() => mockApi.get<List<dynamic>>('/users')).called(1);
@@ -157,7 +159,7 @@ void main() {
       final (users, _) = await repository.fetchUsers();
 
       // Assert (検証)
-      expect(users, isEmpty);
+      check(users).isEmpty();
 
       verify(() => mockApi.get<List<dynamic>>('/users')).called(1);
       verifyNever(() => mockCache.save(any<String>(), any<dynamic>()));
@@ -183,9 +185,9 @@ void main() {
       );
 
       // Assert (検証)
-      expect(users.length, 1);
-      expect(users.first.name, 'Test User 1');
-      expect(fetchedAt, DateTime(2026, 5, 17, 10));
+      check(users.length).equals(1);
+      check(users.first.name).equals('Test User 1');
+      check(fetchedAt).equals(DateTime(2026, 5, 17, 10));
 
       verifyNever(() => mockCache.getWithTimestamp(any<String>()));
 
@@ -208,10 +210,9 @@ void main() {
 
       // Act & Assert (実行と検証)
       // エラーがリポジトリで握りつぶされず、そのまま上位（Notifier）に伝播することを確認
-      await expectLater(
+      check(
         () => repository.fetchUsers(),
-        throwsA(exception),
-      );
+      ).legacyMatcher(throwsA(exception));
 
       // エラーが起きたので、キャッシュ保存は絶対に呼ばれていないことを確認
       verifyNever(() => mockCache.save(any<String>(), any<dynamic>()));
@@ -240,8 +241,8 @@ void main() {
       );
 
       // Assert
-      expect(result.id, 1);
-      expect(result.name, 'Test User 1');
+      check(result.id).equals(1);
+      check(result.name).equals('Test User 1');
       verify(
         () => mockApi.post<Map<String, dynamic>>(
           '/users',
@@ -278,8 +279,8 @@ void main() {
       final result = await repository.updateUserName(1, 'Updated Name');
 
       // Assert
-      expect(result.id, 1);
-      expect(result.name, 'Updated Name');
+      check(result.id).equals(1);
+      check(result.name).equals('Updated Name');
       verify(
         () => mockApi.patch<Map<String, dynamic>>(
           '/users/1',
@@ -319,8 +320,9 @@ void main() {
       ).thenAnswer((_) async => mockResponse);
 
       // Act & Assert
-      expect(
+      check(
         () => repository.createUser('Name', 'email@example.com'),
+      ).legacyMatcher(
         throwsA(
           isA<Exception>().having(
             (e) => e.toString(),
@@ -343,8 +345,7 @@ void main() {
       ).thenAnswer((_) async => mockResponse);
 
       // Act & Assert
-      expect(
-        () => repository.updateUserName(1, 'New Name'),
+      check(() => repository.updateUserName(1, 'New Name')).legacyMatcher(
         throwsA(
           isA<Exception>().having(
             (e) => e.toString(),
@@ -381,10 +382,10 @@ void main() {
         final repository = container.read(userRepositoryProvider);
 
         // 3. Assert (検証)
-        expect(repository, isA<UserRepository>());
+        check(repository).isA<UserRepository>();
 
-        expect(repository.api, equals(mockApi));
-        expect(repository.cache, equals(mockCache));
+        check(repository.api).equals(mockApi);
+        check(repository.cache).equals(mockCache);
       },
     );
   });

--- a/test/src/features/user/data/user_repository_test.dart
+++ b/test/src/features/user/data/user_repository_test.dart
@@ -210,9 +210,12 @@ void main() {
 
       // Act & Assert (実行と検証)
       // エラーがリポジトリで握りつぶされず、そのまま上位（Notifier）に伝播することを確認
-      check(
-        () => repository.fetchUsers(),
-      ).legacyMatcher(throwsA(exception));
+      try {
+        await repository.fetchUsers();
+        fail('Exception not thrown');
+      } on Exception catch (e) {
+        check(e).equals(exception);
+      }
 
       // エラーが起きたので、キャッシュ保存は絶対に呼ばれていないことを確認
       verifyNever(() => mockCache.save(any<String>(), any<dynamic>()));

--- a/test/src/features/user/domain/user_model_test.dart
+++ b/test/src/features/user/domain/user_model_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter_sample/src/features/user/domain/address.dart';
 import 'package:flutter_sample/src/features/user/domain/user_model.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,40 +22,40 @@ void main() {
 
     test('Address.fromJson', () {
       final address = Address.fromJson(dummyAddressJson);
-      expect(address.city, 'Tokyo');
-      expect(address.street, 'Test Street');
-      expect(address.suite, 'Suite 1');
+      check(address.city).equals('Tokyo');
+      check(address.street).equals('Test Street');
+      check(address.suite).equals('Suite 1');
     });
 
     test('Address.toJson', () {
       final address = Address.fromJson(dummyAddressJson);
       final json = address.toJson();
-      expect(json, dummyAddressJson);
+      check(json).deepEquals(dummyAddressJson);
     });
 
     test('UserModel.fromJson', () {
       final user = UserModel.fromJson(dummyUserJson);
-      expect(user.id, 1);
-      expect(user.name, 'Test User');
-      expect(user.address.city, 'Tokyo');
+      check(user.id).equals(1);
+      check(user.name).equals('Test User');
+      check(user.address.city).equals('Tokyo');
     });
 
     test('UserModel.toJson', () {
       final user = UserModel.fromJson(dummyUserJson);
       final json = user.toJson();
 
-      expect(json['id'], 1);
-      expect(json['name'], 'Test User');
+      check(json['id']).equals(1);
+      check(json['name']).equals('Test User');
       // 💡 AddressがMapになっていない（Objectのまま）場合の挙動に合わせる
-      expect(json['address'], isA<Address>());
-      expect((json['address'] as Address).city, 'Tokyo');
+      check(json['address']).isA<Address>();
+      check((json['address'] as Address).city).equals('Tokyo');
     });
 
     test('UserModel equality', () {
       final user1 = UserModel.fromJson(dummyUserJson);
       final user2 = UserModel.fromJson(dummyUserJson);
-      expect(user1, equals(user2));
-      expect(user1.hashCode, equals(user2.hashCode));
+      check(user1).equals(user2);
+      check(user1.hashCode).equals(user2.hashCode);
     });
   });
 }

--- a/test/src/features/user/presentation/user_list_screen_test.dart
+++ b/test/src/features/user/presentation/user_list_screen_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/features/user/data/user_repository.dart';
@@ -90,9 +92,8 @@ void main() {
 
   group('UserListScreen Test', () {
     test('コンストラクタのテスト', () {
-      // ignore: prefer_const_constructors, 100%カバレッジのために意図的にconstを外している
-      final screen = UserListScreen(key: const ValueKey<String>('test'));
-      expect(screen.key, isA<ValueKey<String>>());
+      const screen = UserListScreen(key: ValueKey<String>('test'));
+      check(screen.key).isA<ValueKey<String>>();
     });
     testWidgets('【状態系】Loading状態の時にインジケータが表示されること', (tester) async {
       final completer = Completer<(List<UserModel>, DateTime)>();
@@ -103,7 +104,7 @@ void main() {
       await pumpUserListScreen(tester);
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      check(find.byType(CircularProgressIndicator)).findsOne();
     });
 
     testWidgets('【正常系】Data状態でユーザー一覧が正しく表示され、カードをタップできること', (tester) async {
@@ -115,12 +116,12 @@ void main() {
       await pumpUserListScreen(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('User List'), findsOneWidget);
-      expect(find.text('Last fetched: 2026/05/17 10:30'), findsOneWidget);
-      expect(find.text('Test User 1'), findsOneWidget);
-      expect(find.text('test1@example.com'), findsOneWidget);
-      expect(find.text('Test User 2'), findsOneWidget);
-      expect(find.byType(Card), findsNWidgets(2));
+      check(find.text('User List')).findsOne();
+      check(find.text('Last fetched: 2026/05/17 10:30')).findsOne();
+      check(find.text('Test User 1')).findsOne();
+      check(find.text('test1@example.com')).findsOne();
+      check(find.text('Test User 2')).findsOne();
+      check(find.byType(Card)).findsExactly(2);
 
       await tester.tap(find.text('Test User 1'));
       await tester.pumpAndSettle();
@@ -134,8 +135,8 @@ void main() {
       await pumpUserListScreen(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('No users found.'), findsOneWidget);
-      expect(find.byIcon(Icons.people_outline), findsOneWidget);
+      check(find.text('No users found.')).findsOne();
+      check(find.byIcon(Icons.people_outline)).findsOne();
     });
 
     testWidgets('【正常系】引っ張って更新（Pull-to-Refresh）でデータが再取得されること', (tester) async {
@@ -177,8 +178,8 @@ void main() {
       await pumpUserListScreen(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('Error Occurred'), findsNWidgets(2));
-      expect(find.text('Pull to refresh'), findsOneWidget);
+      check(find.text('Error Occurred')).findsExactly(2);
+      check(find.text('Pull to refresh')).findsOne();
 
       // リトライ実行前に SnackBar を消去して干渉を防ぐ
       ScaffoldMessenger.of(
@@ -193,14 +194,13 @@ void main() {
 
       verify(() => mockRepository.fetchUsers(forceRefresh: true)).called(1);
       // リトライ成功後は body のエラー表示が消え、空表示になっていること
-      expect(
+      check(
         find.descendant(
           of: find.byType(RefreshIndicator),
           matching: find.byIcon(Icons.error_outline),
         ),
-        findsNothing,
-      );
-      expect(find.text('No users found.'), findsOneWidget);
+      ).findsNothing();
+      check(find.text('No users found.')).findsOne();
     });
 
     testWidgets('【正常系】データ保持時にエラーが発生した場合でも、以前のリストが表示され続けること', (tester) async {
@@ -212,7 +212,7 @@ void main() {
       await pumpUserListScreen(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('Test User 1'), findsOneWidget);
+      check(find.text('Test User 1')).findsOne();
 
       when(
         () => mockRepository.fetchUsers(forceRefresh: true),
@@ -223,15 +223,14 @@ void main() {
       await tester.pump(const Duration(seconds: 1));
       await tester.pumpAndSettle();
 
-      expect(find.text('Test User 1'), findsOneWidget);
-      expect(
+      check(find.text('Test User 1')).findsOne();
+      check(
         find.descendant(
           of: find.byType(RefreshIndicator),
           matching: find.byIcon(Icons.error_outline),
         ),
-        findsNothing,
-      );
-      expect(find.byType(SnackBar), findsNothing);
+      ).findsNothing();
+      check(find.byType(SnackBar)).findsNothing();
     });
   });
 }


### PR DESCRIPTION
## 📝 概要

- pubspec.yaml に checks、flutter_checks、legacy_checks パッケージを追加
- 全71件のテストコードを expect() から check() を使った新しい書き方に変更
- ドキュメント（persistence.md や theme.md など）のサンプルコードも新しい書き方に更新
- 全439件のテストが正常に合格し、プログラムの分析エラーがないことを確認

## ✅ 確認事項

- [x] AI（Gemini Code Assist）によるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューはPR作成時に自動で行われますが、ドラフトの場合は実行されないのでドラフトを解除したタイミングで手動実行（`/gemini review`） すること
  - レビュー後に大幅な変更を行った場合は手動で再度レビューを実行（`/gemini review`） すること

- [ ] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)
- [ ] レビューアーに依頼する前にプルリクエストの要約（サマリー）をAIに作成（`/gemini summary`） してもらっているか

## ❕ 関連するIssue

Closes #140 
