### PR TITLE
fix: Firebase認証初期化時のローディング判定を追加し、起動時の画面チラつきを修正 (#138)

### DIFF
--- a/docs/firebase_authentication.md
+++ b/docs/firebase_authentication.md
@@ -22,7 +22,7 @@ lib/src/features/auth/
  ├── data/
  │    └── firebase_auth_repository.dart       # Firebase APIの呼び出し（ログイン・登録）
  └── application/
-      └── firebase_auth_state_notifier.dart   # 現在のユーザー(User?)の状態管理
+      └── firebase_auth_state_notifier.dart   # 現在のユーザー(AsyncValue<User?>)の状態管理
 ```
 
 ---

--- a/lib/src/app/router/firebase_auth_guard.dart
+++ b/lib/src/app/router/firebase_auth_guard.dart
@@ -13,8 +13,15 @@ String? firebaseAuthGuard(Ref ref, GoRouterState state) {
     return const SplashRoute().location;
   }
 
-  // 現在のログイン状態を取得（コールバック内のため watch ではなく read を使用）
-  final authState = ref.read(firebaseAuthStateProvider);
+  // ログイン状態（ローディング状態含む）を取得
+  final authStateAsync = ref.read(firebaseAuthStateProvider);
+
+  // Firebaseのログイン確認が終わっていない（ローディング中）なら、スプラッシュ画面にとどまる
+  if (authStateAsync.isLoading) {
+    return const SplashRoute().location;
+  }
+
+  final authState = authStateAsync.value;
 
   // ユーザーがログイン済みかどうか
   final isLoggedIn = authState != null;

--- a/lib/src/features/auth/application/firebase_auth_state_notifier.dart
+++ b/lib/src/features/auth/application/firebase_auth_state_notifier.dart
@@ -8,10 +8,8 @@ part 'firebase_auth_state_notifier.g.dart';
 @Riverpod(keepAlive: true)
 class FirebaseAuthStateNotifier extends _$FirebaseAuthStateNotifier {
   @override
-  User? build() {
-    // 新しく作成した StreamProvider を監視し、
-    // 最新の非同期データ（User?）を同期的に返すようにする
-    final asyncUser = ref.watch(authStateChangesProvider);
-    return asyncUser.value;
+  AsyncValue<User?> build() {
+    // 認証状態の監視ストリームをそのまま状態として管理する
+    return ref.watch(authStateChangesProvider);
   }
 }

--- a/lib/src/features/auth/application/firebase_auth_state_notifier.g.dart
+++ b/lib/src/features/auth/application/firebase_auth_state_notifier.g.dart
@@ -15,7 +15,7 @@ final firebaseAuthStateProvider = FirebaseAuthStateNotifierProvider._();
 
 /// Firebase Authenticationの認証状態を管理するStateNotifier
 final class FirebaseAuthStateNotifierProvider
-    extends $NotifierProvider<FirebaseAuthStateNotifier, User?> {
+    extends $NotifierProvider<FirebaseAuthStateNotifier, AsyncValue<User?>> {
   /// Firebase Authenticationの認証状態を管理するStateNotifier
   FirebaseAuthStateNotifierProvider._()
     : super(
@@ -36,30 +36,31 @@ final class FirebaseAuthStateNotifierProvider
   FirebaseAuthStateNotifier create() => FirebaseAuthStateNotifier();
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(User? value) {
+  Override overrideWithValue(AsyncValue<User?> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<User?>(value),
+      providerOverride: $SyncValueProvider<AsyncValue<User?>>(value),
     );
   }
 }
 
 String _$firebaseAuthStateNotifierHash() =>
-    r'b71b585b543232c8b81e018a86f02a729ce972f6';
+    r'ce7898dbee8ee494000ad238268cb078816d89fd';
 
 /// Firebase Authenticationの認証状態を管理するStateNotifier
 
-abstract class _$FirebaseAuthStateNotifier extends $Notifier<User?> {
-  User? build();
+abstract class _$FirebaseAuthStateNotifier
+    extends $Notifier<AsyncValue<User?>> {
+  AsyncValue<User?> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<User?, User?>;
+    final ref = this.ref as $Ref<AsyncValue<User?>, AsyncValue<User?>>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<User?, User?>,
-              User?,
+              AnyNotifier<AsyncValue<User?>, AsyncValue<User?>>,
+              AsyncValue<User?>,
               Object?,
               Object?
             >;

--- a/lib/src/features/memos/application/memo_notifier.g.dart
+++ b/lib/src/features/memos/application/memo_notifier.g.dart
@@ -153,7 +153,7 @@ final class MemoNotifierProvider
   MemoNotifier create() => MemoNotifier();
 }
 
-String _$memoNotifierHash() => r'cb9c76d45923aab82c89a26a844d7896f9a35939';
+String _$memoNotifierHash() => r'75bde6ad3223ec81567b7a5428b84b4fd15d870d';
 
 /// メモ一覧のデータ（状態）を管理するためのクラス
 

--- a/test/src/app/router/app_router_test.dart
+++ b/test/src/app/router/app_router_test.dart
@@ -85,13 +85,15 @@ class _FakeFirebaseAuthStateNotifier extends FirebaseAuthStateNotifier {
   _FakeFirebaseAuthStateNotifier({required this.isLoggedIn, this.mockUser});
   final bool isLoggedIn;
   final User? mockUser;
+
   @override
-  User? build() => isLoggedIn ? mockUser : null;
+  AsyncValue<User?> build() {
+    return isLoggedIn ? AsyncData(mockUser) : const AsyncData(null);
+  }
 
   // 外部からFirebaseのログイン状態を強制的に変更するメソッド
-  // ignore: use_setters_to_change_properties
   void changeState(User? user) {
-    state = user;
+    state = AsyncData(user);
   }
 }
 
@@ -143,6 +145,11 @@ void main() {
     required bool useFirebase,
     bool isSplashFinished = true,
   }) {
+    final fakeNotifier = _FakeFirebaseAuthStateNotifier(
+      isLoggedIn: isLoggedIn,
+      mockUser: mockUser,
+    );
+
     final container = ProviderContainer(
       overrides: [
         chatRepositoryProvider.overrideWithValue(mockChatRepository),
@@ -164,10 +171,7 @@ void main() {
           () => _FakeAuthStateNotifier(isLoggedIn: isLoggedIn),
         ),
         firebaseAuthStateProvider.overrideWith(
-          () => _FakeFirebaseAuthStateNotifier(
-            isLoggedIn: isLoggedIn,
-            mockUser: mockUser,
-          ),
+          () => fakeNotifier,
         ),
         splashStateProvider.overrideWith(
           () => FakeSplashState(initialValue: isSplashFinished),

--- a/test/src/app/router/firebase_auth_guard_test.dart
+++ b/test/src/app/router/firebase_auth_guard_test.dart
@@ -31,7 +31,7 @@ void main() {
   });
 
   String? executeGuard(
-    User? user, {
+    AsyncValue<User?> authState, {
     String location = '/',
     bool isSplashFinished = true,
   }) {
@@ -39,8 +39,8 @@ void main() {
 
     final container = ProviderContainer(
       overrides: [
-        // firebaseAuthStateProvider を指定した User オブジェクトで上書き
-        firebaseAuthStateProvider.overrideWithValue(user),
+        // firebaseAuthStateProvider に authState (AsyncValue<User?>) を直接上書き
+        firebaseAuthStateProvider.overrideWithValue(authState),
         splashStateProvider.overrideWith(
           () => FakeSplashState(initialValue: isSplashFinished),
         ),
@@ -52,11 +52,17 @@ void main() {
   }
 
   group('firebaseAuthGuard テスト', () {
+    test('ログイン確認中（ローディング中）の場合、SplashRoute にリダイレクトすること', () {
+      final result = executeGuard(const AsyncLoading<User?>());
+
+      check(result).equals(const SplashRoute().location);
+    });
+
     test('ログイン済みかつメール未認証の場合、メール認証画面へリダイレクトすること', () {
       final mockUser = MockUser();
       when(() => mockUser.emailVerified).thenReturn(false);
 
-      final result = executeGuard(mockUser);
+      final result = executeGuard(AsyncData(mockUser));
 
       check(result).equals(const EmailVerificationRoute().location);
     });
@@ -66,7 +72,7 @@ void main() {
       when(() => mockUser.emailVerified).thenReturn(false);
 
       final result = executeGuard(
-        mockUser,
+        AsyncData(mockUser),
         location: const EmailVerificationRoute().location,
       );
 
@@ -80,7 +86,7 @@ void main() {
 
       // ログイン済みでログイン画面にいる場合
       final result = executeGuard(
-        mockUser,
+        AsyncData(mockUser),
         location: const LoginRoute().location,
       );
 
@@ -90,7 +96,7 @@ void main() {
 
     test('未ログインの場合、AuthGuardHelper に判定が委譲されること', () {
       // ユーザーが null (未ログイン)
-      final result = executeGuard(null);
+      final result = executeGuard(const AsyncData(null));
 
       // AuthGuardHelper によりログイン画面へリダイレクトされることを確認（fromパラメータ付き）
       check(result).isNotNull().startsWith(const LoginRoute().location);
@@ -100,7 +106,7 @@ void main() {
     test('スプラッシュ未完了の場合、常に SplashRoute にリダイレクトすること', () {
       final mockUser = MockUser();
       final result = executeGuard(
-        mockUser,
+        AsyncData(mockUser),
         isSplashFinished: false,
       );
       check(result).equals(const SplashRoute().location);
@@ -109,7 +115,7 @@ void main() {
     test('スプラッシュ完了後、スプラッシュ画面にいてログイン済みの場合、ホーム画面へリダイレクトすること', () {
       final mockUser = MockUser();
       final result = executeGuard(
-        mockUser,
+        AsyncData(mockUser),
         location: const SplashRoute().location,
       );
       check(result).equals(const HomeRoute().location);
@@ -117,7 +123,7 @@ void main() {
 
     test('スプラッシュ完了後、スプラッシュ画面にいて未ログインの場合、ログイン画面へリダイレクトすること', () {
       final result = executeGuard(
-        null,
+        const AsyncData(null),
         location: const SplashRoute().location,
       );
       check(result).equals(const LoginRoute().location);

--- a/test/src/features/auth/application/firebase_auth_state_notifier_test.dart
+++ b/test/src/features/auth/application/firebase_auth_state_notifier_test.dart
@@ -28,7 +28,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        // 💡 修正1: listen を使って Provider を「監視状態」にし、勝手に破棄されるのを防ぐ
+        // listen を使って Provider を「監視状態」にし、勝手に破棄されるのを防ぐ
         container.listen(firebaseAuthStateProvider, (_, _) {});
 
         // 非同期データが流れて状態が同期されるまで1フレーム待つ
@@ -38,7 +38,7 @@ void main() {
         final state = container.read(firebaseAuthStateProvider);
 
         // Assert
-        check(state).equals(mockUser);
+        check(state.value).equals(mockUser);
       },
     );
 
@@ -62,12 +62,12 @@ void main() {
         final state = container.read(firebaseAuthStateProvider);
 
         // Assert
-        check(state).isNull();
+        check(state.value).isNull();
       },
     );
 
     test(
-      'ロード中: authStateChangesProvider がまだ値を流していない時、state は null になること',
+      'ロード中: authStateChangesProvider がまだ値を流していない時、state は AsyncLoading になること',
       () async {
         // Arrange
         final streamController = StreamController<User?>();
@@ -89,9 +89,9 @@ void main() {
         final state = container.read(firebaseAuthStateProvider);
 
         // Assert
-        check(state).isNull();
+        check(state).isA<AsyncLoading<User?>>();
 
-        // 💡 修正2: Riverpodのエラー（Bad state）を回避するため、
+        // Riverpodのエラー（Bad state）を回避するため、
         // テスト終了直前にダミーの値を流して「ロード状態」を平和に終わらせる
         streamController.add(null);
         await Future<void>.delayed(Duration.zero);

--- a/test/src/features/auth/presentation/firebase_email_verification_screen_test.dart
+++ b/test/src/features/auth/presentation/firebase_email_verification_screen_test.dart
@@ -39,7 +39,9 @@ class FakeFirebaseAuthStateNotifier extends FirebaseAuthStateNotifier {
   final User? initialState;
 
   @override
-  User? build() => initialState;
+  AsyncValue<User?> build() {
+    return AsyncData(initialState);
+  }
 }
 
 class FakeAppLifecycle extends AppLifecycle {


### PR DESCRIPTION
## 📝 概要

Firebase Authenticationの初期化処理中に、一瞬ログイン画面（`LoginRoute`）が表示されてしまうチラつき（フラッシュ）の問題（Issue #138）を修正しました。

### 主な変更内容
- **firebase_auth_state_notifier.dart の修正**:
  - 認証状態の提供を `User?` から `AsyncValue<User?>` に変更し、初期化中のローディング状態（`AsyncLoading`）を明示的にキャッチできるようにしました。
- **firebase_auth_guard.dart の修正**:
  - 認証状態がローディング中（`isLoading`）の場合は、ログイン画面へ遷移させず、スプラッシュ画面（`SplashRoute`）に留まるように制御フローを修正しました。
- **テストコードの修正**:
  - `app_router_test.dart`、`firebase_auth_guard_test.dart` などの各テストにおいて、新しい `AsyncValue<User?>` 状態を Riverpod で `overrideWithValue`
  を用いて同期的にモックするようにリファクタリングし、全テスト（440件）が正常にパスすることを確認しました。
- **ドキュメントの修正**:
  - 状態変更に伴い、firebase_authentication.md 内の `firebase_auth_state_notifier.dart` の解説記述（型情報）を更新しました。

## ✅ 確認事項

- [x] AIによるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューは、プルリクエストの作成時（※下書き/ドラフト状態を除く）および、公開後のプルリクエストに新しいコミットが追加（プッシュ）されたタイミングで自動実行されます。
  - **下書き（ドラフト）状態では自動実行されません。** 下書きの状態でレビューを動かしたい場合や、手動で再実行したい場合は、プルリクエストのコメント欄で `@coderabbitai review` と入力してください。
  - コメント欄で以下のコマンドを使用し、CodeRabbitの動きをコントロールできます：
    - `@coderabbitai review` : 新しく追加された変更箇所（差分）だけをレビューします。
    - `@coderabbitai full review` : プルリクエスト全体のプログラムを最初からレビューし直します。
    - `@coderabbitai pause` : 自動レビューを一時停止します。
    - `@coderabbitai resume` : 自動レビューを再開します。

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)

## ❕ 関連するIssue

Closes #138 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * Firebase認証の状態管理を強化し、認証確認中の読み込み状態を適切に処理するようにしました。
  * 認証状態の確認中はスプラッシュ画面で待機するようになり、ナビゲーション制御がより堅牢になりました。

* **テスト**
  * 認証システムのテストを更新し、ローディング状態を含むすべての認証シナリオに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->