### PR TITLE
feat(memo): メモ機能のAPI部分をモックサーバー(json-server)通信に置き換え

### DIFF
--- a/lib/src/features/memos/data/memo_remote_service.dart
+++ b/lib/src/features/memos/data/memo_remote_service.dart
@@ -25,10 +25,16 @@ class MemoRemoteService {
     return data.map((e) {
       final map = Map<String, dynamic>.from(e as Map);
       if (map['createdAt'] is String) {
-        map['createdAt'] = DateTime.parse(map['createdAt'] as String);
+        final parsed = DateTime.tryParse(map['createdAt'] as String);
+        if (parsed != null) {
+          map['createdAt'] = parsed;
+        }
       }
       if (map['updatedAt'] is String) {
-        map['updatedAt'] = DateTime.parse(map['updatedAt'] as String);
+        final parsed = DateTime.tryParse(map['updatedAt'] as String);
+        if (parsed != null) {
+          map['updatedAt'] = parsed;
+        }
       }
       return map;
     }).toList();
@@ -55,7 +61,7 @@ class MemoRemoteService {
 
     try {
       // まずはPUTリクエストで既存メモの更新を試みます
-      await _api.put<void>('/memos/$id', data: memoData);
+      await _api.put<void>('/memos/${Uri.encodeComponent(id)}', data: memoData);
     } on DioException catch (e) {
       // サーバーからの直接の返事、または共通処理で包み直された独自エラーからステータスコードを取り出します（二重チェック）
       final error = e.error;

--- a/lib/src/features/memos/data/memo_remote_service.dart
+++ b/lib/src/features/memos/data/memo_remote_service.dart
@@ -1,18 +1,37 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_sample/src/core/exceptions/app_exception.dart';
+import 'package:flutter_sample/src/core/network/api_client.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'memo_remote_service.g.dart';
 
 /// サーバーやクラウドと通信するためのクラス
-/// （今回は本物のサーバーを使わず、Mockを使用）
 class MemoRemoteService {
-  final List<Map<String, dynamic>> _mockServerData = [];
+  /// ApiClientを受け取って初期化します
+  MemoRemoteService(this._api);
+
+  final ApiClient _api;
 
   /// サーバーからメモのデータを取得する
   Future<List<Map<String, dynamic>>> fetchMemos() async {
-    // 実際に通信しているように見せるため、1秒間待つ
-    await Future<void>.delayed(const Duration(seconds: 1));
+    // サーバーの /memos エンドポイントからデータを取得します
+    final response = await _api.get<List<dynamic>>('/memos');
+    final data = response.data;
+    if (data == null) {
+      return [];
+    }
 
-    return _mockServerData;
+    // JSONの日付文字列を DateTime 型に復元してリストにして返します
+    return data.map((e) {
+      final map = Map<String, dynamic>.from(e as Map);
+      if (map['createdAt'] is String) {
+        map['createdAt'] = DateTime.parse(map['createdAt'] as String);
+      }
+      if (map['updatedAt'] is String) {
+        map['updatedAt'] = DateTime.parse(map['updatedAt'] as String);
+      }
+      return map;
+    }).toList();
   }
 
   /// メモをサーバーに保存（または更新）する
@@ -24,24 +43,32 @@ class MemoRemoteService {
     required DateTime updatedAt,
     required bool isDeleted,
   }) async {
-    // 実際に通信しているように見せるため、1秒間待つ
-    await Future<void>.delayed(const Duration(seconds: 1));
-
-    // すでに同じIDのメモがあれば上書きし、なければ追加する
-    final existingIndex = _mockServerData.indexWhere((m) => m['id'] == id);
+    // サーバーに送信するためのMap形式データを作ります。日付は文字列に変換します。
     final memoData = {
       'id': id,
       'title': title,
       'content': content,
-      'createdAt': createdAt,
-      'updatedAt': updatedAt,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
       'isDeleted': isDeleted,
     };
 
-    if (existingIndex >= 0) {
-      _mockServerData[existingIndex] = memoData;
-    } else {
-      _mockServerData.add(memoData);
+    try {
+      // まずはPUTリクエストで既存メモの更新を試みます
+      await _api.put<void>('/memos/$id', data: memoData);
+    } on DioException catch (e) {
+      // サーバーからの直接の返事、または共通処理で包み直された独自エラーからステータスコードを取り出します（二重チェック）
+      final error = e.error;
+      final statusCode =
+          e.response?.statusCode ??
+          (error is AppException ? error.statusCode : null);
+
+      // 404 (データが見つからない) エラーの場合のみ、POSTリクエストで新規登録を行います
+      if (statusCode == 404) {
+        await _api.post<void>('/memos', data: memoData);
+      } else {
+        rethrow;
+      }
     }
   }
 }
@@ -49,5 +76,5 @@ class MemoRemoteService {
 /// [MemoRemoteService] をアプリのどこからでも簡単に呼び出せるようにするためのプロバイダー
 @riverpod
 MemoRemoteService memoRemoteService(Ref ref) {
-  return MemoRemoteService();
+  return MemoRemoteService(ref.watch(apiClientProvider));
 }

--- a/lib/src/features/memos/data/memo_remote_service.g.dart
+++ b/lib/src/features/memos/data/memo_remote_service.g.dart
@@ -58,4 +58,4 @@ final class MemoRemoteServiceProvider
   }
 }
 
-String _$memoRemoteServiceHash() => r'5680d4c83d8c3dc021d9eac52a73f0b317ba8c4d';
+String _$memoRemoteServiceHash() => r'9302ce93780f134849d7d12421678e268b45889e';

--- a/mock/db.json
+++ b/mock/db.json
@@ -307,5 +307,15 @@
   },
   "refresh": {
     "access_token": "dummy_new_access_token_789"
-  }
+  },
+  "memos": [
+    {
+      "id": "4bced173-4cff-4cad-beb8-e9b74c806a85",
+      "title": "メモ1",
+      "content": "メモ1の中身",
+      "createdAt": "2026-06-13T13:30:07.000",
+      "updatedAt": "2026-06-13T13:30:07.000",
+      "isDeleted": false
+    }
+  ]
 }

--- a/test/src/features/memos/data/memo_remote_service_test.dart
+++ b/test/src/features/memos/data/memo_remote_service_test.dart
@@ -63,6 +63,35 @@ void main() {
       check(result).isEmpty();
     });
 
+    test(
+      'fetchMemos: 日付が不正な形式の場合はパースをスキップし、元の文字列を保持すること',
+      () async {
+        final mockData = [
+          {
+            'id': 'memo1',
+            'title': 'テストタイトル',
+            'content': 'テストコンテンツ',
+            'createdAt': 'invalid-date-string',
+            'updatedAt': 'invalid-date-string',
+            'isDeleted': false,
+          },
+        ];
+
+        when(() => mockApiClient.get<List<dynamic>>('/memos')).thenAnswer(
+          (_) async => Response(
+            data: mockData,
+            requestOptions: RequestOptions(path: '/memos'),
+          ),
+        );
+
+        final result = await service.fetchMemos();
+
+        check(result.length).equals(1);
+        check(result.first['createdAt']).equals('invalid-date-string');
+        check(result.first['updatedAt']).equals('invalid-date-string');
+      },
+    );
+
     test('uploadMemo: PUTが成功した場合、POSTは呼ばれないこと', () async {
       final now = DateTime(2026, 5, 2);
       final memoData = {
@@ -238,6 +267,42 @@ void main() {
         () => mockApiClient.post<void>(any(), data: any(named: 'data')),
       );
     });
+
+    test(
+      'uploadMemo: IDに特殊文字が含まれる場合、URLエンコードされたパスでPUTされること',
+      () async {
+        final now = DateTime(2026, 5, 2);
+        final memoData = {
+          'id': 'memo 1',
+          'title': 'タイトル',
+          'content': 'コンテンツ',
+          'createdAt': now.toIso8601String(),
+          'updatedAt': now.toIso8601String(),
+          'isDeleted': false,
+        };
+
+        when(
+          () => mockApiClient.put<void>('/memos/memo%201', data: memoData),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/memos/memo%201'),
+          ),
+        );
+
+        await service.uploadMemo(
+          id: 'memo 1',
+          title: 'タイトル',
+          content: 'コンテンツ',
+          createdAt: now,
+          updatedAt: now,
+          isDeleted: false,
+        );
+
+        verify(
+          () => mockApiClient.put<void>('/memos/memo%201', data: memoData),
+        ).called(1);
+      },
+    );
   });
 
   group('memoRemoteServiceProvider', () {

--- a/test/src/features/memos/data/memo_remote_service_test.dart
+++ b/test/src/features/memos/data/memo_remote_service_test.dart
@@ -1,34 +1,46 @@
 import 'package:checks/checks.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_sample/src/core/exceptions/app_exception.dart';
+import 'package:flutter_sample/src/core/network/api_client.dart';
 import 'package:flutter_sample/src/features/memos/data/memo_remote_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
 
 void main() {
   group('MemoRemoteService', () {
+    late MockApiClient mockApiClient;
     late MemoRemoteService service;
 
     setUp(() {
-      service = MemoRemoteService();
+      mockApiClient = MockApiClient();
+      service = MemoRemoteService(mockApiClient);
     });
 
-    test('初期状態ではfetchMemosは空のリストを返すこと', () async {
-      final result = await service.fetchMemos();
-      check(result).isNotNull().isEmpty();
-    });
-
-    test('uploadMemoで新しいメモを追加し、fetchMemosで取得できること', () async {
+    test('fetchMemos: 正常系', () async {
       final now = DateTime(2026, 5, 2);
+      final mockData = [
+        {
+          'id': 'memo1',
+          'title': 'テストタイトル',
+          'content': 'テストコンテンツ',
+          'createdAt': now.toIso8601String(),
+          'updatedAt': now.toIso8601String(),
+          'isDeleted': false,
+        },
+      ];
 
-      await service.uploadMemo(
-        id: 'memo1',
-        title: 'テストタイトル',
-        content: 'テストコンテンツ',
-        createdAt: now,
-        updatedAt: now,
-        isDeleted: false,
+      when(() => mockApiClient.get<List<dynamic>>('/memos')).thenAnswer(
+        (_) async => Response(
+          data: mockData,
+          requestOptions: RequestOptions(path: '/memos'),
+        ),
       );
 
       final result = await service.fetchMemos();
+
       check(result.length).equals(1);
       check(result.first['id']).equals('memo1');
       check(result.first['title']).equals('テストタイトル');
@@ -36,46 +48,206 @@ void main() {
       check(result.first['createdAt']).equals(now);
       check(result.first['updatedAt']).equals(now);
       check(result.first['isDeleted']).equals(false);
+
+      verify(() => mockApiClient.get<List<dynamic>>('/memos')).called(1);
     });
 
-    test('uploadMemoで既存のメモを更新できること', () async {
-      final now = DateTime(2026, 5, 2);
+    test('fetchMemos: データがnullの場合、空のリストを返すこと', () async {
+      when(() => mockApiClient.get<List<dynamic>>('/memos')).thenAnswer(
+        (_) async => Response(
+          requestOptions: RequestOptions(path: '/memos'),
+        ),
+      );
 
-      // 初回の追加
+      final result = await service.fetchMemos();
+      check(result).isEmpty();
+    });
+
+    test('uploadMemo: PUTが成功した場合、POSTは呼ばれないこと', () async {
+      final now = DateTime(2026, 5, 2);
+      final memoData = {
+        'id': 'memo1',
+        'title': 'タイトル',
+        'content': 'コンテンツ',
+        'createdAt': now.toIso8601String(),
+        'updatedAt': now.toIso8601String(),
+        'isDeleted': false,
+      };
+
+      when(
+        () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+      ).thenAnswer(
+        (_) async => Response(
+          requestOptions: RequestOptions(path: '/memos/memo1'),
+        ),
+      );
+
       await service.uploadMemo(
         id: 'memo1',
-        title: '古いタイトル',
-        content: '古いコンテンツ',
+        title: 'タイトル',
+        content: 'コンテンツ',
         createdAt: now,
         updatedAt: now,
         isDeleted: false,
       );
 
-      // 更新
-      final updatedTime = now.add(const Duration(hours: 1));
-      await service.uploadMemo(
-        id: 'memo1', // 同じID
-        title: '新しいタイトル',
-        content: '新しいコンテンツ',
-        createdAt: now,
-        updatedAt: updatedTime,
-        isDeleted: true,
+      verify(
+        () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+      ).called(1);
+      verifyNever(
+        () => mockApiClient.post<void>(any(), data: any(named: 'data')),
+      );
+    });
+
+    test('uploadMemo: PUTが404エラーの場合、POSTが呼ばれること', () async {
+      final now = DateTime(2026, 5, 2);
+      final memoData = {
+        'id': 'memo1',
+        'title': 'タイトル',
+        'content': 'コンテンツ',
+        'createdAt': now.toIso8601String(),
+        'updatedAt': now.toIso8601String(),
+        'isDeleted': false,
+      };
+
+      // PUTの段階で404エラーをスローさせる
+      when(
+        () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+      ).thenThrow(
+        DioException(
+          requestOptions: RequestOptions(path: '/memos/memo1'),
+          response: Response(
+            statusCode: 404,
+            requestOptions: RequestOptions(path: '/memos/memo1'),
+          ),
+        ),
       );
 
-      final result = await service.fetchMemos();
-      check(result.length).equals(1); // 追加されず上書きされていること
-      check(result.first['id']).equals('memo1');
-      check(result.first['title']).equals('新しいタイトル');
-      check(result.first['content']).equals('新しいコンテンツ');
-      check(result.first['createdAt']).equals(now);
-      check(result.first['updatedAt']).equals(updatedTime);
-      check(result.first['isDeleted']).equals(true);
+      when(() => mockApiClient.post<void>('/memos', data: memoData)).thenAnswer(
+        (_) async => Response(
+          requestOptions: RequestOptions(path: '/memos'),
+        ),
+      );
+
+      await service.uploadMemo(
+        id: 'memo1',
+        title: 'タイトル',
+        content: 'コンテンツ',
+        createdAt: now,
+        updatedAt: now,
+        isDeleted: false,
+      );
+
+      verify(
+        () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+      ).called(1);
+      verify(
+        () => mockApiClient.post<void>('/memos', data: memoData),
+      ).called(1);
+    });
+
+    test(
+      'uploadMemo: PUTが404エラー（responseがnullでe.errorがAppExceptionの場合） '
+      'でも、POSTが呼ばれること',
+      () async {
+        final now = DateTime(2026, 5, 2);
+        final memoData = {
+          'id': 'memo1',
+          'title': 'タイトル',
+          'content': 'コンテンツ',
+          'createdAt': now.toIso8601String(),
+          'updatedAt': now.toIso8601String(),
+          'isDeleted': false,
+        };
+
+        // responseがnullで、errorにAppException.badRequest(statusCode: 404)が
+        // 入った状態をシミュレートします
+        when(
+          () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+        ).thenThrow(
+          DioException(
+            requestOptions: RequestOptions(path: '/memos/memo1'),
+            error: const AppException.badRequest(statusCode: 404),
+          ),
+        );
+
+        when(
+          () => mockApiClient.post<void>('/memos', data: memoData),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/memos'),
+          ),
+        );
+
+        await service.uploadMemo(
+          id: 'memo1',
+          title: 'タイトル',
+          content: 'コンテンツ',
+          createdAt: now,
+          updatedAt: now,
+          isDeleted: false,
+        );
+
+        verify(
+          () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+        ).called(1);
+        verify(
+          () => mockApiClient.post<void>(any(), data: any(named: 'data')),
+        ).called(1);
+      },
+    );
+
+    test('uploadMemo: PUTが404以外のエラーの場合、例外がそのままスローされること', () async {
+      final now = DateTime(2026, 5, 2);
+      final memoData = {
+        'id': 'memo1',
+        'title': 'タイトル',
+        'content': 'コンテンツ',
+        'createdAt': now.toIso8601String(),
+        'updatedAt': now.toIso8601String(),
+        'isDeleted': false,
+      };
+
+      when(
+        () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+      ).thenThrow(
+        DioException(
+          requestOptions: RequestOptions(path: '/memos/memo1'),
+          response: Response(
+            statusCode: 500,
+            requestOptions: RequestOptions(path: '/memos/memo1'),
+          ),
+        ),
+      );
+
+      await check(
+        service.uploadMemo(
+          id: 'memo1',
+          title: 'タイトル',
+          content: 'コンテンツ',
+          createdAt: now,
+          updatedAt: now,
+          isDeleted: false,
+        ),
+      ).throws<DioException>();
+
+      verify(
+        () => mockApiClient.put<void>('/memos/memo1', data: memoData),
+      ).called(1);
+      verifyNever(
+        () => mockApiClient.post<void>(any(), data: any(named: 'data')),
+      );
     });
   });
 
   group('memoRemoteServiceProvider', () {
     test('Provider経由でMemoRemoteServiceのインスタンスを取得できること', () {
-      final container = ProviderContainer();
+      final mockApiClient = MockApiClient();
+      final container = ProviderContainer(
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApiClient),
+        ],
+      );
       addTearDown(container.dispose);
 
       final service = container.read(memoRemoteServiceProvider);


### PR DESCRIPTION
## 📝 概要
メモ機能（Memos）の API 部分（`MemoRemoteService`）を、現在インメモリで擬似的に動作している状態から、ローカルモックサーバー（`json-server`）と通信する実装に置き換えます。

### 実施内容
1. **`mock/db.json` の更新**
   - 末尾に `"memos": []` を追加し、モックサーバーのデータ領域を確保。
2. **`MemoRemoteService` のリファクタリング**
   - `ApiClient` を注入し、共通クライアント経由で `/memos` エンドポイントと通信。
   - `fetchMemos()`: GET でデータを取得し、JSONの日付文字列（String）を `DateTime` オブジェクトに変換して返却。
   - `uploadMemo()`: `PUT /memos/id` を試みて、404 の場合に `POST /memos` にフォールバックする安全な upsert 処理を実装。
3. **二重チェック（404判定）の導入**
   - 共通処理（`dioInterceptor`）でのエラー包み直しにより `e.response` が null になる問題を回避するため、`e.response?.statusCode` に加え、`e.error (AppException)` から `statusCode` を参照するフォールバックロジックを実装。
4. **より安全な通信のための追加対応**
   - `fetchMemos()`: 日付文字列のパースに `DateTime.tryParse()` を使用し、不正な形式が含まれていてもクラッシュしないように安全化。
   - `uploadMemo()`: `id` に特殊文字（予約文字）が含まれている場合に対応するため、URLエンコード（`Uri.encodeComponent`）したパスでリクエストを送るように修正。
5. **テストコードの刷新と追加**
   - `test/src/features/memos/data/memo_remote_service_test.dart` のテストを mocktail + checks に刷新。
   - 二重チェックのルートおよび追加の安全性対策（tryParse、URLエンコード）のテストケースを追加し、カバレッジ 100% を達成。

## ✅ 確認事項

- [x] AIによるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューは、プルリクエストの作成時（※下書き/ドラフト状態を除く）および、公開後のプルリクエストに新しいコミットが追加（プッシュ）されたタイミングで自動実行されます。
  - **下書き（ドラフト）状態では自動実行されません。** 下書きの状態でレビューを動かしたい場合や、手動で再実行したい場合は、プルリクエストのコメント欄で `@coderabbitai review` と入力してください。
  - コメント欄で以下のコマンドを使用し、CodeRabbitの動きをコントロールできます：
    - `@coderabbitai review` : 新しく追加された変更箇所（差分）だけをレビューします。
    - `@coderabbitai full review` : プルリクエスト全体のプログラムを最初からレビューし直します。
    - `@coderabbitai pause` : 自動レビューを一時停止します。
    - `@coderabbitai resume` : 自動レビューを再開します。

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)

## ❕ 関連するIssue

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * メモのデータ通信処理がモック実装から実通信に対応しました。ネットワークエラーや不正なレスポンスへの対応が強化され、通信の堅牢性が向上しました。

* **Tests**
  * API通信を含むメモ処理のテストが拡充され、エラーケースの検証が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->