### PR TITLE
test: テストにおける checks パッケージの適用と多言語モックの導入 (Issue #164)

### DIFF
--- a/test/src/app/router/app_router_test.dart
+++ b/test/src/app/router/app_router_test.dart
@@ -7,7 +7,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/app/router/app_router.dart';
 import 'package:flutter_sample/src/app/router/main_shell_screen.dart';
 import 'package:flutter_sample/src/core/analytics/analytics_service.dart';
@@ -43,6 +42,8 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:talker_flutter/talker_flutter.dart';
+
+import '../../core/widgets/widgets_test_helper.dart';
 
 class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
@@ -120,6 +121,8 @@ void main() {
   late MockUser mockUser;
   late MockChatRepository mockChatRepository;
   late MockMemoRepository mockMemoRepository;
+  late MockAppLocalizations mockL10n;
+  late List<LocalizationsDelegate<dynamic>> testLocalizations;
 
   setUp(() {
     mockAnalytics = MockFirebaseAnalytics();
@@ -127,6 +130,14 @@ void main() {
     mockUser = MockUser();
     mockChatRepository = MockChatRepository();
     mockMemoRepository = MockMemoRepository();
+    mockL10n = MockAppLocalizations();
+
+    testLocalizations = [
+      MockLocalizationsDelegate(mockL10n),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ];
 
     when(
       () => mockMemoRepository.getAllMemos(),
@@ -154,14 +165,99 @@ void main() {
         screenName: any(named: 'screenName'),
       ),
     ).thenAnswer((_) async {});
-  });
 
-  final testLocalizations = [
-    AppLocalizations.delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-  ];
+    // Stub all l10n keys used in tests
+    when(() => mockL10n.onboardingSkip).thenReturn('Skip');
+    when(() => mockL10n.onboardingNext).thenReturn('Next');
+    when(() => mockL10n.onboardingStart).thenReturn('Get Started');
+    when(() => mockL10n.onboardingPage1Title).thenReturn('Page 1 Title');
+    when(() => mockL10n.onboardingPage1Desc).thenReturn('Page 1 Desc');
+    when(() => mockL10n.onboardingPage2Title).thenReturn('Page 2 Title');
+    when(() => mockL10n.onboardingPage2Desc).thenReturn('Page 2 Desc');
+    when(() => mockL10n.onboardingPage3Title).thenReturn('Page 3 Title');
+    when(() => mockL10n.onboardingPage3Desc).thenReturn('Page 3 Desc');
+    when(() => mockL10n.loginTitle).thenReturn('Login');
+    when(() => mockL10n.loginEmailLabel).thenReturn('Email');
+    when(() => mockL10n.loginPasswordLabel).thenReturn('Password');
+    when(() => mockL10n.login).thenReturn('Login Button');
+    when(() => mockL10n.loginButton).thenReturn('Login Button');
+    when(() => mockL10n.signUp).thenReturn('Sign Up');
+    when(() => mockL10n.googleSignUp).thenReturn('Google Sign Up');
+    when(() => mockL10n.resetPassword).thenReturn('Forgot Password?');
+    when(() => mockL10n.errorLoginFailed).thenReturn('Login Failed');
+    when(() => mockL10n.errorUnknown).thenReturn('Unknown Error');
+    when(() => mockL10n.ok).thenReturn('OK');
+    when(() => mockL10n.close).thenReturn('Close');
+    when(() => mockL10n.homeTitle).thenReturn('Home');
+    when(() => mockL10n.homeDescription).thenReturn('Home Desc');
+    when(() => mockL10n.homeCurrentEnv).thenReturn('Current Env');
+    when(() => mockL10n.homeToSettings).thenReturn('Settings');
+    when(() => mockL10n.homeToUserList).thenReturn('User List');
+    when(() => mockL10n.homeToResetPassword).thenReturn('Reset Password');
+    when(() => mockL10n.homeToChat).thenReturn('AI Chat');
+    when(() => mockL10n.homeToMemos).thenReturn('Memos');
+    when(() => mockL10n.homeToGraph).thenReturn('Graph');
+    when(() => mockL10n.homeToNotFound).thenReturn('404');
+    when(() => mockL10n.homeGetAppInfo).thenReturn('App Info');
+    when(() => mockL10n.homeAppName).thenReturn('App Name');
+    when(() => mockL10n.homeBundleId).thenReturn('Bundle ID');
+    when(() => mockL10n.homeCrashTest).thenReturn('Crash Test');
+    when(() => mockL10n.homeAnalyticsTest).thenReturn('Analytics Test');
+    when(() => mockL10n.developerLogTitle).thenReturn('Dev Log');
+    when(() => mockL10n.versionUpTitle).thenReturn('Update');
+    when(() => mockL10n.versionUpMessageOptional).thenReturn('Optional');
+    when(() => mockL10n.versionUpMessageMandatory).thenReturn('Mandatory');
+    when(() => mockL10n.versionUpUpdate).thenReturn('Update Button');
+    when(() => mockL10n.versionUpCancel).thenReturn('Cancel Button');
+    when(() => mockL10n.devStorageTitle).thenReturn('Storage');
+    when(() => mockL10n.chatTitle).thenReturn('Chat');
+    when(() => mockL10n.memoTitle).thenReturn('Memo');
+    when(() => mockL10n.navHome).thenReturn('Home');
+    when(() => mockL10n.navChat).thenReturn('Chat');
+    when(() => mockL10n.navMemos).thenReturn('Memo');
+    when(() => mockL10n.navChart).thenReturn('Chart');
+    when(() => mockL10n.navUsers).thenReturn('User');
+    when(
+      () => mockL10n.emailVerificationTitle,
+    ).thenReturn('Email Verification');
+    when(
+      () => mockL10n.emailVerificationDescription,
+    ).thenReturn('Verify Email');
+    when(() => mockL10n.resendVerificationMail).thenReturn('Resend');
+    when(() => mockL10n.emailVerificationWaiting).thenReturn('Waiting');
+    when(() => mockL10n.checkVerificationStatus).thenReturn('Check Status');
+    when(() => mockL10n.logout).thenReturn('Logout');
+    when(() => mockL10n.chartClearAll).thenReturn('Clear All');
+    when(() => mockL10n.chartClearConfirm).thenReturn('Confirm Clear');
+    when(() => mockL10n.thinking).thenReturn('Thinking...');
+    when(() => mockL10n.chatHint).thenReturn('Type a message');
+    when(() => mockL10n.memoSyncing).thenReturn('Syncing...');
+    when(() => mockL10n.memoEmpty).thenReturn('No memos');
+    when(() => mockL10n.memoSearchHint).thenReturn('Search memos');
+    when(() => mockL10n.memoSynced).thenReturn('Synced');
+    when(() => mockL10n.memoUnsynced).thenReturn('Unsynced');
+    when(() => mockL10n.userListTitle).thenReturn('User List');
+    when(() => mockL10n.userListLastFetched(any())).thenAnswer(
+      (inv) => 'Last Fetched: ${inv.positionalArguments[0]}',
+    );
+    when(() => mockL10n.userListEmpty).thenReturn('No Users');
+    when(() => mockL10n.userListFetchError).thenReturn('Fetch Error');
+    when(() => mockL10n.chartLine).thenReturn('Line Chart');
+    when(() => mockL10n.chartBar).thenReturn('Bar Chart');
+    when(() => mockL10n.chartPie).thenReturn('Pie Chart');
+    when(() => mockL10n.chartDisplayTitle(any())).thenAnswer(
+      (inv) => 'Display: ${inv.positionalArguments[0]}',
+    );
+    when(() => mockL10n.chartNoData).thenReturn('No Chart Data');
+    when(() => mockL10n.chartDataList).thenReturn('Chart Data List');
+    when(() => mockL10n.notFoundTitle).thenReturn('Page Not Found');
+    when(() => mockL10n.notFoundMessage).thenReturn(
+      'The page could not be found.',
+    );
+    when(() => mockL10n.notFoundBackToHome).thenReturn('Back to Home');
+    when(() => mockL10n.appTitle).thenReturn('Flutter Sample');
+    when(() => mockL10n.memoAdd).thenReturn('Add Memo');
+  });
 
   ProviderContainer createContainer({
     required bool isLoggedIn,
@@ -675,13 +771,13 @@ void main() {
       check(find.byType(OnboardingScreen)).findsOne();
 
       // 「次へ」をタップして3ページ目へ進む
-      await tester.tap(find.text('次へ'));
+      await tester.tap(find.text(mockL10n.onboardingNext));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('次へ'));
+      await tester.tap(find.text(mockL10n.onboardingNext));
       await tester.pumpAndSettle();
 
       // 「はじめる」をタップしてオンボーディングを完了させる
-      await tester.tap(find.text('はじめる'));
+      await tester.tap(find.text(mockL10n.onboardingStart));
       await tester.pumpAndSettle();
 
       // onboardingProvider の変更によりルーターが再評価され、LoginScreenに遷移することを確認
@@ -707,19 +803,25 @@ void main() {
       // 各タブが表示されていることの確認（NavigationBar内のテキストを検索）
       check(find.byType(NavigationBar)).findsOne();
       final navBar = find.byType(NavigationBar);
-      check(find.descendant(of: navBar, matching: find.text('ホーム'))).findsOne();
       check(
-        find.descendant(of: navBar, matching: find.text('チャット')),
+        find.descendant(of: navBar, matching: find.text(mockL10n.navHome)),
       ).findsOne();
-      check(find.descendant(of: navBar, matching: find.text('メモ'))).findsOne();
-      check(find.descendant(of: navBar, matching: find.text('グラフ'))).findsOne();
       check(
-        find.descendant(of: navBar, matching: find.text('ユーザー')),
+        find.descendant(of: navBar, matching: find.text(mockL10n.navChat)),
+      ).findsOne();
+      check(
+        find.descendant(of: navBar, matching: find.text(mockL10n.navMemos)),
+      ).findsOne();
+      check(
+        find.descendant(of: navBar, matching: find.text(mockL10n.navChart)),
+      ).findsOne();
+      check(
+        find.descendant(of: navBar, matching: find.text(mockL10n.navUsers)),
       ).findsOne();
 
       // チャットタブ（インデックス1）をタップする
       await tester.tap(
-        find.descendant(of: navBar, matching: find.text('チャット')),
+        find.descendant(of: navBar, matching: find.text(mockL10n.navChat)),
       );
       await tester.pumpAndSettle();
 
@@ -728,12 +830,14 @@ void main() {
 
       // 同じチャットタブを再度タップする（initialLocation: true の分岐をテストするため）
       await tester.tap(
-        find.descendant(of: navBar, matching: find.text('チャット')),
+        find.descendant(of: navBar, matching: find.text(mockL10n.navChat)),
       );
       await tester.pumpAndSettle();
 
       // メモタブ（インデックス2）をタップする
-      await tester.tap(find.descendant(of: navBar, matching: find.text('メモ')));
+      await tester.tap(
+        find.descendant(of: navBar, matching: find.text(mockL10n.navMemos)),
+      );
       await tester.pumpAndSettle();
 
       // MemoScreen に切り替わっていることを確認

--- a/test/src/core/widgets/version_up_dialog_test.dart
+++ b/test/src/core/widgets/version_up_dialog_test.dart
@@ -2,13 +2,31 @@ import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/widgets/version_up_dialog.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'widgets_test_helper.dart';
 
 void main() {
   group('VersionUpDialog', () {
+    late MockAppLocalizations mockL10n;
+
+    setUp(() {
+      mockL10n = MockAppLocalizations();
+
+      when(() => mockL10n.versionUpTitle).thenReturn('Version Update');
+      when(
+        () => mockL10n.versionUpMessageOptional,
+      ).thenReturn('A new version is available.');
+      when(
+        () => mockL10n.versionUpMessageMandatory,
+      ).thenReturn('A new version is required.');
+      when(() => mockL10n.versionUpCancel).thenReturn('Later');
+      when(() => mockL10n.versionUpUpdate).thenReturn('Update');
+    });
+
     // テスト用のウィジェットを構築するヘルパー関数
     Widget createTestWidget(
       void Function(BuildContext) showDialogCallback,
@@ -31,13 +49,13 @@ void main() {
 
       return MaterialApp.router(
         routerConfig: router,
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
+        localizationsDelegates: [
+          MockLocalizationsDelegate(mockL10n),
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,
         ],
-        supportedLocales: AppLocalizations.supportedLocales,
+        supportedLocales: const [Locale('ja'), Locale('en')],
       );
     }
 
@@ -55,18 +73,25 @@ void main() {
           );
         }),
       );
+      await tester.pumpAndSettle();
 
       // ダイアログ表示
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
       check(find.byType(AlertDialog)).findsOne();
-      check(find.text('A new version is available.')).findsOne();
-      check(find.widgetWithText(TextButton, 'Later')).findsOne();
-      check(find.widgetWithText(TextButton, 'Update')).findsOne();
+      check(find.text(mockL10n.versionUpMessageOptional)).findsOne();
+      check(
+        find.widgetWithText(TextButton, mockL10n.versionUpCancel),
+      ).findsOne();
+      check(
+        find.widgetWithText(TextButton, mockL10n.versionUpUpdate),
+      ).findsOne();
 
       // アップデートボタン
-      await tester.tap(find.widgetWithText(TextButton, 'Update'));
+      await tester.tap(
+        find.widgetWithText(TextButton, mockL10n.versionUpUpdate),
+      );
       await tester.pumpAndSettle();
       check(onUpdateCalled).equals(true);
       check(find.byType(AlertDialog)).findsNothing();
@@ -74,7 +99,9 @@ void main() {
       // 再表示してキャンセルボタン
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(TextButton, 'Later'));
+      await tester.tap(
+        find.widgetWithText(TextButton, mockL10n.versionUpCancel),
+      );
       await tester.pumpAndSettle();
       check(onCancelCalled).equals(true);
       check(find.byType(AlertDialog)).findsNothing();
@@ -93,14 +120,17 @@ void main() {
           );
         }),
       );
+      await tester.pumpAndSettle();
 
       // ダイアログ表示
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
       check(find.byType(AlertDialog)).findsOne();
-      check(find.text('A new version is required.')).findsOne();
-      check(find.widgetWithText(TextButton, 'Later')).findsNothing();
+      check(find.text(mockL10n.versionUpMessageMandatory)).findsOne();
+      check(
+        find.widgetWithText(TextButton, mockL10n.versionUpCancel),
+      ).findsNothing();
 
       // ダイアログ外タップで閉じないこと
       await tester.tapAt(Offset.zero);
@@ -108,7 +138,9 @@ void main() {
       check(find.byType(AlertDialog)).findsOne();
 
       // アップデート
-      await tester.tap(find.widgetWithText(TextButton, 'Update'));
+      await tester.tap(
+        find.widgetWithText(TextButton, mockL10n.versionUpUpdate),
+      );
       await tester.pumpAndSettle();
       check(onUpdateCalled).equals(true);
       check(find.byType(AlertDialog)).findsNothing();
@@ -127,6 +159,7 @@ void main() {
           );
         }),
       );
+      await tester.pumpAndSettle();
 
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();

--- a/test/src/features/onboarding/presentation/onboarding_screen_test.dart
+++ b/test/src/features/onboarding/presentation/onboarding_screen_test.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/src/core/storage/shared_preferences_provider.dart';
 import 'package:flutter_sample/src/features/onboarding/presentation/onboarding_screen.dart';
@@ -43,59 +45,50 @@ void main() {
       await pumpOnboardingScreen(tester);
 
       // 1ページ目のタイトルと説明文が表示されていること
-      expect(find.text('シンプルなメモ機能'), findsOneWidget);
-      expect(
-        find.text('思いついたアイデアやタスクを、いつでもどこでもすばやくメモに残すことができます。'),
-        findsOneWidget,
-      );
+      check(find.text(mockL10n.onboardingPage1Title)).findsOne();
+      check(find.text(mockL10n.onboardingPage1Desc)).findsOne();
 
       // スキップボタンと次へボタンがあること
-      expect(find.text('Skip'), findsOneWidget);
-      expect(find.text('Next'), findsOneWidget);
-      expect(find.text('Get Started'), findsNothing);
+      check(find.text(mockL10n.onboardingSkip)).findsOne();
+      check(find.text(mockL10n.onboardingNext)).findsOne();
+      check(find.text(mockL10n.onboardingStart)).findsNothing();
     });
 
     testWidgets('「次へ」ボタンをタップすると2枚目のスライドに切り替わること', (tester) async {
       await pumpOnboardingScreen(tester);
 
       // 「次へ」をタップ
-      await tester.tap(find.text('Next'));
+      await tester.tap(find.text(mockL10n.onboardingNext));
       await tester.pumpAndSettle();
 
       // 2ページ目の表示
-      expect(find.text('どこでもつながる同期機能'), findsOneWidget);
-      expect(
-        find.text('インターネットがないオフライン環境でもメモを書くことができ、接続時に自動でクラウドへ同期されます。'),
-        findsOneWidget,
-      );
-      expect(find.text('Next'), findsOneWidget);
-      expect(find.text('Get Started'), findsNothing);
+      check(find.text(mockL10n.onboardingPage2Title)).findsOne();
+      check(find.text(mockL10n.onboardingPage2Desc)).findsOne();
+      check(find.text(mockL10n.onboardingNext)).findsOne();
+      check(find.text(mockL10n.onboardingStart)).findsNothing();
     });
 
     testWidgets('3枚目のスライドで「はじめる」ボタンが表示され、タップすると完了処理が呼ばれること', (tester) async {
       await pumpOnboardingScreen(tester);
 
       // 2ページ目に切り替え
-      await tester.tap(find.text('Next'));
+      await tester.tap(find.text(mockL10n.onboardingNext));
       await tester.pumpAndSettle();
 
       // 3ページ目に切り替え
-      await tester.tap(find.text('Next'));
+      await tester.tap(find.text(mockL10n.onboardingNext));
       await tester.pumpAndSettle();
 
       // 3ページ目の表示
-      expect(find.text('AIチャットアシスタント'), findsOneWidget);
-      expect(
-        find.text('メモのまとめを作ったり、アイデアのブレインストーミングをAIアシスタントがサポートします。'),
-        findsOneWidget,
-      );
+      check(find.text(mockL10n.onboardingPage3Title)).findsOne();
+      check(find.text(mockL10n.onboardingPage3Desc)).findsOne();
 
       // 「はじめる」に変わっていること
-      expect(find.text('Next'), findsNothing);
-      expect(find.text('Get Started'), findsOneWidget);
+      check(find.text(mockL10n.onboardingNext)).findsNothing();
+      check(find.text(mockL10n.onboardingStart)).findsOne();
 
       // 「はじめる」をタップすると、SharedPreferencesに保存されること
-      await tester.tap(find.text('Get Started'));
+      await tester.tap(find.text(mockL10n.onboardingStart));
       await tester.pump(); // Notifierの非同期処理を発火
 
       verify(() => mockPrefs.setBool('onboarding_completed', true)).called(1);
@@ -105,7 +98,7 @@ void main() {
       await pumpOnboardingScreen(tester);
 
       // 「Skip」をタップ
-      await tester.tap(find.text('Skip'));
+      await tester.tap(find.text(mockL10n.onboardingSkip));
       await tester.pump();
 
       verify(() => mockPrefs.setBool('onboarding_completed', true)).called(1);


### PR DESCRIPTION
## 📝 概要

プロジェクトの絶対ルールである「`expect` の廃止（`package:checks` / `check()` への移行）」および「翻訳メッセージのモック化（`MockAppLocalizations` によるスタブ化とテキストハードコードの排除）」を以下のテストファイルに適用しました。

### 対象テストファイル
1. [onboarding_screen_test.dart](file:///Users/a.sasaoka/develop/flutter/flutter_sample/test/src/features/onboarding/presentation/onboarding_screen_test.dart)
2. [version_up_dialog_test.dart](file:///Users/a.sasaoka/develop/flutter/flutter_sample/test/src/core/widgets/version_up_dialog_test.dart)
3. [app_router_test.dart](file:///Users/a.sasaoka/develop/flutter/flutter_sample/test/src/app/router/app_router_test.dart)

### 主な修正内容
- `expect(...)` のアサーションを `check(...)`（`package:checks`）に書き換えました。
- 画面内で参照される `AppLocalizations` を `MockAppLocalizations` / `MockLocalizationsDelegate` に差し替え、ハードコードされたテキストアサーションをモックオブジェクト（`mockL10n`）から取得した値に置き換えました。
- `version_up_dialog_test.dart` にてモックローカライズの非同期読み込みによってテスト対象ボタン（`ElevatedButton`）が即座に描画されない問題を解決するため、`pumpWidget` の直後に `await tester.pumpAndSettle()` を追加しました。
- `app_router_test.dart` における Linter 警告（`lines_longer_than_80_chars`）を解消するために改行を調整しました。

## ✅ 確認事項

- [x] AIによるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューは、プルリクエストの作成時（※下書き/ドラフト状態を除く）および、公開後のプルリクエストに新しいコミットが追加（プッシュ）されたタイミングで自動実行されます。
  - **下書き（ドラフト）状態では自動実行されません。** 下書きの状態でレビューを動かしたい場合や、手動で再実行したい場合は、プルリクエストのコメント欄で `@coderabbitai review` と入力してください。
  - コメント欄で以下のコマンドを使用し、CodeRabbitの動きをコントロールできます：
    - `@coderabbitai review` : 新しく追加された変更箇所（差分）だけをレビューします。
    - `@coderabbitai full review` : プルリクエスト全体のプログラムを最初からレビューし直します。
    - `@coderabbitai pause` : 自動レビューを一時停止します。
    - `@coderabbitai resume` : 自動レビューを再開します。

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)

## ❕ 関連するIssue

Closes #164 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テスト用のローカライゼーション処理を更新し、テストの検証基盤を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->