### PR TITLE
feat: Firebase AuthのIDトークンを使用したAPI認証統合と動的切り替えの実装

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -99,3 +99,18 @@ dio.interceptors.add(ref.watch(dioInterceptorProvider));
 この構成により、UI層（画面側）のコードは一切トークンの存在を意識することなく、シンプルにAPIを呼び出すだけで安全な認証フローを実現できます。
 
 ---
+
+## 🔄 Firebase Auth モードとの自動切り替え
+
+本プロジェクトでは、環境設定（`EnvConfig`）の `useFirebaseAuth` フラグに基づいて、認証トークン方式を動的に切り替えます。
+
+- **自前サーバー認証モード (`useFirebaseAuth: false`)**:
+  - `tokenStorageProvider` は上書きされず、デフォルトのままで動作し、Secure Storage からアクセストークンを取得します。
+  - `tokenRefreshCallbackProvider` は自前の `authRepository.refreshToken()` を実行します。
+- **Firebase Auth モード (`useFirebaseAuth: true`)**:
+  - `tokenStorageProvider` を `FirebaseAuthTokenStorage` に差し替え、Firebase から直接 ID トークンを取得します。
+  - `tokenRefreshCallbackProvider` は Firebase の `user.getIdToken(true)` を実行して強制的に更新します。
+
+この切り替えは、アプリのエントリーポイント（`main.dart`）の `ProviderContainer` のオーバーライド定義（`overrideWith`）内で `ref.watch(envConfigProvider)` を監視し、条件分岐によって返却するインスタンスや処理を動的に切り替えることで実現しています。
+これにより、Riverpodの仕様である「起動後に上書き設定（overrides）の数を動的に変更できない」という制約を回避し、クラッシュを防止しつつ安全に動作を切り替えています。
+詳細な仕様は [Firebase Authenticationによる認証対応](firebase_authentication.md) を参照してください。

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -105,7 +105,7 @@ dio.interceptors.add(ref.watch(dioInterceptorProvider));
 本プロジェクトでは、環境設定（`EnvConfig`）の `useFirebaseAuth` フラグに基づいて、認証トークン方式を動的に切り替えます。
 
 - **自前サーバー認証モード (`useFirebaseAuth: false`)**:
-  - `tokenStorageProvider` は上書きされず、デフォルトのままで動作し、Secure Storage からアクセストークンを取得します。
+  - `tokenStorageProvider` はオーバーライドされて Secure Storage で裏付けされた `TokenStorage` を返し、そこからアクセストークンを取得します。
   - `tokenRefreshCallbackProvider` は自前の `authRepository.refreshToken()` を実行します。
 - **Firebase Auth モード (`useFirebaseAuth: true`)**:
   - `tokenStorageProvider` を `FirebaseAuthTokenStorage` に差し替え、Firebase から直接 ID トークンを取得します。

--- a/docs/firebase_authentication.md
+++ b/docs/firebase_authentication.md
@@ -105,3 +105,13 @@ ref.listen(appLifecycleProvider, (previous, next) {
 これにより、iOS/Android 双方で安定したソーシャルログインを提供します。
 
 ---
+
+## 🌐 APIリクエストとの統合 (IDトークンの自動付与)
+
+環境設定で `useFirebaseAuth` が `true` に設定されている場合、API通信（Dio）の認証に Firebase Auth の IDトークンが自動的に使用されます。
+
+- **仕組み**: `main.dart` でのアプリ起動時に、通信用のプロバイダ（`tokenStorageProvider` / `tokenRefreshCallbackProvider`）のオーバーライド定義の中で `ref.watch(envConfigProvider)` を監視し、環境フラグに応じてFirebase用の挙動（`FirebaseAuthTokenStorage` 等）に自動で切り替えます。
+- **自動付与**: APIを呼び出す際、裏側で `FirebaseAuthTokenStorage` が自動的に `user.getIdToken()` を取得し、 `Authorization: Bearer <IDトークン>` ヘッダーを付与します。
+- **自動リフレッシュ**: IDトークンが期限切れになり、APIから `401 Unauthorized` が返ってきた場合は、 `getIdToken(true)` が実行されて強制的にトークンが更新され、自動的に元のAPIリクエストが再試行（リトライ）されます。
+
+詳細は [トークン認証対応（Bearer Token + 自動リフレッシュ）](auth.md) を参照してください。

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,10 +15,14 @@ import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_sample/src/core/config/firebase_options.dart';
 import 'package:flutter_sample/src/core/config/flavor_provider.dart';
 import 'package:flutter_sample/src/core/network/token_interceptor.dart';
+import 'package:flutter_sample/src/core/storage/secure_storage_provider.dart';
+import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_sample/src/core/utils/logger_provider.dart';
 import 'package:flutter_sample/src/core/utils/package_info_provider.dart';
 import 'package:flutter_sample/src/core/utils/scaffold_messenger_key.dart';
 import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
+import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
+import 'package:flutter_sample/src/features/auth/data/firebase_auth_token_storage.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:talker_flutter/talker_flutter.dart';
@@ -76,10 +80,36 @@ Future<void> mainCommon(Flavor flavor) async {
       // プロバイダーにPackageInfoを設定
       packageInfoProvider.overrideWithValue(packageInfo),
 
-      // プロバイダーにTokenRefreshCallbackを設定
-      tokenRefreshCallbackProvider.overrideWith(
-        (ref) => ref.watch(authRepositoryProvider).refreshToken,
-      ),
+      // プロバイダーにTokenStorageを設定（クラスのフラグで動的に切り替え）
+      tokenStorageProvider.overrideWith((ref) {
+        final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
+        if (useFirebase) {
+          return FirebaseAuthTokenStorage(ref.watch(firebaseAuthProvider));
+        }
+        return TokenStorage(secureStorage: ref.watch(secureStorageProvider));
+      }),
+
+      // プロバイダーにTokenRefreshCallbackを設定（クラスのフラグで動的に切り替え）
+      tokenRefreshCallbackProvider.overrideWith((ref) {
+        final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
+        if (useFirebase) {
+          return () async {
+            try {
+              final user = ref.read(firebaseAuthProvider).currentUser;
+              if (user != null) {
+                await user.getIdToken(true);
+                return true;
+              }
+              return false;
+            } on Exception catch (_) {
+              return false;
+            }
+          };
+        }
+        return () async {
+          return ref.read(authRepositoryProvider).refreshToken();
+        };
+      }),
 
       // プロバイダーにTalkerを設定
       loggerProvider.overrideWithValue(talker),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,8 +97,8 @@ Future<void> mainCommon(Flavor flavor) async {
             try {
               final user = ref.read(firebaseAuthProvider).currentUser;
               if (user != null) {
-                await user.getIdToken(true);
-                return true;
+                final token = await user.getIdToken(true);
+                return token != null;
               }
               return false;
             } on Exception catch (_) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,15 +14,10 @@ import 'package:flutter_sample/src/core/config/app_theme.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_sample/src/core/config/firebase_options.dart';
 import 'package:flutter_sample/src/core/config/flavor_provider.dart';
-import 'package:flutter_sample/src/core/network/token_interceptor.dart';
-import 'package:flutter_sample/src/core/storage/secure_storage_provider.dart';
-import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_sample/src/core/utils/logger_provider.dart';
 import 'package:flutter_sample/src/core/utils/package_info_provider.dart';
 import 'package:flutter_sample/src/core/utils/scaffold_messenger_key.dart';
-import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
-import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
-import 'package:flutter_sample/src/features/auth/data/firebase_auth_token_storage.dart';
+import 'package:flutter_sample/src/features/auth/data/auth_overrides.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:talker_flutter/talker_flutter.dart';
@@ -80,36 +75,8 @@ Future<void> mainCommon(Flavor flavor) async {
       // プロバイダーにPackageInfoを設定
       packageInfoProvider.overrideWithValue(packageInfo),
 
-      // プロバイダーにTokenStorageを設定（クラスのフラグで動的に切り替え）
-      tokenStorageProvider.overrideWith((ref) {
-        final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
-        if (useFirebase) {
-          return FirebaseAuthTokenStorage(ref.watch(firebaseAuthProvider));
-        }
-        return TokenStorage(secureStorage: ref.watch(secureStorageProvider));
-      }),
-
-      // プロバイダーにTokenRefreshCallbackを設定（クラスのフラグで動的に切り替え）
-      tokenRefreshCallbackProvider.overrideWith((ref) {
-        final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
-        if (useFirebase) {
-          return () async {
-            try {
-              final user = ref.read(firebaseAuthProvider).currentUser;
-              if (user != null) {
-                final token = await user.getIdToken(true);
-                return token != null;
-              }
-              return false;
-            } on Exception catch (_) {
-              return false;
-            }
-          };
-        }
-        return () async {
-          return ref.read(authRepositoryProvider).refreshToken();
-        };
-      }),
+      // 動的切り替えを含む共通の認証オーバーライド設定を追加
+      ...getAuthOverrides().cast(),
 
       // プロバイダーにTalkerを設定
       loggerProvider.overrideWithValue(talker),

--- a/lib/src/features/auth/data/auth_overrides.dart
+++ b/lib/src/features/auth/data/auth_overrides.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_sample/src/core/config/env_config.dart';
+import 'package:flutter_sample/src/core/network/token_interceptor.dart';
+import 'package:flutter_sample/src/core/storage/secure_storage_provider.dart';
+import 'package:flutter_sample/src/core/storage/token_storage.dart';
+import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
+import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
+import 'package:flutter_sample/src/features/auth/data/firebase_auth_token_storage.dart';
+
+/// 認証関連のプロバイダーの動的切り替えオーバーライド一覧を取得します。
+List<dynamic> getAuthOverrides() {
+  return [
+    tokenStorageProvider.overrideWith((ref) {
+      final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
+      if (useFirebase) {
+        return FirebaseAuthTokenStorage(ref.watch(firebaseAuthProvider));
+      }
+      return TokenStorage(secureStorage: ref.watch(secureStorageProvider));
+    }),
+    tokenRefreshCallbackProvider.overrideWith((ref) {
+      final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
+      if (useFirebase) {
+        return () async {
+          try {
+            final user = ref.read(firebaseAuthProvider).currentUser;
+            if (user != null) {
+              final token = await user.getIdToken(true);
+              return token != null;
+            }
+            return false;
+          } on Exception catch (_) {
+            return false;
+          }
+        };
+      }
+      return ref.read(authRepositoryProvider).refreshToken;
+    }),
+  ];
+}

--- a/lib/src/features/auth/data/firebase_auth_token_storage.dart
+++ b/lib/src/features/auth/data/firebase_auth_token_storage.dart
@@ -1,0 +1,35 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_sample/src/core/storage/token_storage.dart';
+
+/// Firebase AuthenticationからIDトークンを取得する専用のストレージクラス
+class FirebaseAuthTokenStorage implements TokenStorage {
+  /// コンストラクタ
+  FirebaseAuthTokenStorage(this._firebaseAuth);
+
+  final FirebaseAuth _firebaseAuth;
+
+  @override
+  Future<String?> getAccessToken() async {
+    // ログイン中のユーザーから最新のIDトークンを取得します
+    return _firebaseAuth.currentUser?.getIdToken();
+  }
+
+  @override
+  Future<String?> getRefreshToken() async {
+    // FirebaseではSDKが自動でリフレッシュするため、リフレッシュトークンは個別管理不要です
+    return null;
+  }
+
+  @override
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    // Firebaseが自動保存するため、ここでは何もしません
+  }
+
+  @override
+  Future<void> clear() async {
+    // ログアウト処理は FirebaseAuthRepository が行うため、ここでは何もしません
+  }
+}

--- a/lib/src/features/auth/data/firebase_auth_token_storage.dart
+++ b/lib/src/features/auth/data/firebase_auth_token_storage.dart
@@ -30,6 +30,7 @@ class FirebaseAuthTokenStorage implements TokenStorage {
 
   @override
   Future<void> clear() async {
-    // ログアウト処理は FirebaseAuthRepository が行うため、ここでは何もしません
+    // ログアウト時にFirebase Authからサインアウトし、IDトークンなどをクリアします
+    await _firebaseAuth.signOut();
   }
 }

--- a/test/src/features/auth/data/auth_integration_test.dart
+++ b/test/src/features/auth/data/auth_integration_test.dart
@@ -1,0 +1,186 @@
+import 'package:checks/checks.dart';
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_sample/src/core/config/env_config.dart';
+import 'package:flutter_sample/src/core/network/token_interceptor.dart';
+import 'package:flutter_sample/src/core/storage/secure_storage_provider.dart';
+import 'package:flutter_sample/src/core/storage/token_storage.dart';
+import 'package:flutter_sample/src/core/utils/logger_provider.dart';
+import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
+import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
+import 'package:flutter_sample/src/features/auth/data/firebase_auth_token_storage.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+
+// --- モッククラスの定義 ---
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+
+class MockUser extends Mock implements User {}
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late Talker talker;
+
+  setUp(() {
+    talker = Talker(
+      settings: TalkerSettings(useConsoleLogs: false, useHistory: false),
+    );
+  });
+
+  group('Auth Integration Tests (main.dart 相当のオーバーライド)', () {
+    test(
+      '【useFirebaseAuth: true】 の際、IDトークンが正しくヘッダーにセットされ、'
+      ' リフレッシュ時にIDトークンが強制更新されること',
+      () async {
+        final mockFirebaseAuth = MockFirebaseAuth();
+        final mockUser = MockUser();
+
+        when(() => mockFirebaseAuth.currentUser).thenReturn(mockUser);
+        when(mockUser.getIdToken).thenAnswer((_) async => 'mock_id_token');
+        when(
+          () => mockUser.getIdToken(true),
+        ).thenAnswer((_) async => 'new_mock_id_token');
+
+        // main.dart 相当の上書き設定を持ったコンテナを作成
+        final container = ProviderContainer(
+          overrides: [
+            // 1. 環境フラグを true に設定
+            envConfigProvider.overrideWithValue(
+              const EnvConfigState(
+                baseUrl: 'https://example.com',
+                aiModel: 'gemini-2.5-flash',
+                connectTimeout: 10,
+                receiveTimeout: 15,
+                sendTimeout: 10,
+                useFirebaseAuth: true,
+              ),
+            ),
+            // 2. TokenStorageを Firebase 用に上書き
+            tokenStorageProvider.overrideWith((ref) {
+              return FirebaseAuthTokenStorage(ref.watch(firebaseAuthProvider));
+            }),
+            // 3. リフレッシュコールバックを Firebase 用に上書き
+            tokenRefreshCallbackProvider.overrideWith((ref) {
+              final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
+              if (useFirebase) {
+                return () async {
+                  try {
+                    final user = ref.read(firebaseAuthProvider).currentUser;
+                    if (user != null) {
+                      final token = await user.getIdToken(true);
+                      return token != null;
+                    }
+                    return false;
+                  } on Exception catch (_) {
+                    return false;
+                  }
+                };
+              }
+              return ref.read(authRepositoryProvider).refreshToken;
+            }),
+            firebaseAuthProvider.overrideWithValue(mockFirebaseAuth),
+            loggerProvider.overrideWithValue(talker),
+          ],
+        );
+
+        // --- 認証ヘッダー付与の検証 ---
+        final interceptor = container.read(tokenInterceptorProvider);
+        final options = RequestOptions(path: '/test');
+        final handler = RequestInterceptorHandler();
+
+        await (interceptor as dynamic).onRequest(options, handler);
+
+        // トークンが正しくセットされていること
+        check(options.headers['Authorization']).equals('Bearer mock_id_token');
+
+        // --- リフレッシュ処理の検証 ---
+        final refreshCallback = container.read(tokenRefreshCallbackProvider);
+        final refreshResult = await refreshCallback();
+
+        // 強制更新が成功し、FirebaseのAPIが正しく叩かれていること
+        check(refreshResult).isTrue();
+        verify(() => mockUser.getIdToken(true)).called(1);
+      },
+    );
+
+    test(
+      '【useFirebaseAuth: false】 の際、SecureStorageからアクセストークンが取得され、'
+      ' リフレッシュ時に自前サーバーAPIが呼ばれること',
+      () async {
+        final mockSecureStorage = MockFlutterSecureStorage();
+        final mockAuthRepository = MockAuthRepository();
+
+        when(
+          () => mockSecureStorage.read(key: 'access_token'),
+        ).thenAnswer((_) async => 'mock_access_token');
+        when(mockAuthRepository.refreshToken).thenAnswer((_) async => true);
+
+        // main.dart 相当の上書き設定を持ったコンテナを作成
+        final container = ProviderContainer(
+          overrides: [
+            // 1. 環境フラグを false に設定
+            envConfigProvider.overrideWithValue(
+              const EnvConfigState(
+                baseUrl: 'https://example.com',
+                aiModel: 'gemini-2.5-flash',
+                connectTimeout: 10,
+                receiveTimeout: 15,
+                sendTimeout: 10,
+                useFirebaseAuth: false,
+              ),
+            ),
+            // 2. TokenStorage は上書きせずデフォルトのまま（SecureStorageを使用）
+            secureStorageProvider.overrideWithValue(mockSecureStorage),
+            // 3. リフレッシュコールバックを 自前サーバーAPI に上書き
+            tokenRefreshCallbackProvider.overrideWith((ref) {
+              final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
+              if (useFirebase) {
+                return () async {
+                  try {
+                    final user = ref.read(firebaseAuthProvider).currentUser;
+                    if (user != null) {
+                      final token = await user.getIdToken(true);
+                      return token != null;
+                    }
+                    return false;
+                  } on Exception catch (_) {
+                    return false;
+                  }
+                };
+              }
+              return ref.read(authRepositoryProvider).refreshToken;
+            }),
+            authRepositoryProvider.overrideWithValue(mockAuthRepository),
+            loggerProvider.overrideWithValue(talker),
+          ],
+        );
+
+        // --- 認証ヘッダー付与の検証 ---
+        final interceptor = container.read(tokenInterceptorProvider);
+        final options = RequestOptions(path: '/test');
+        final handler = RequestInterceptorHandler();
+
+        await (interceptor as dynamic).onRequest(options, handler);
+
+        // SecureStorageから取得したアクセストークンがセットされていること
+        check(
+          options.headers['Authorization'],
+        ).equals('Bearer mock_access_token');
+
+        // --- リフレッシュ処理の検証 ---
+        final refreshCallback = container.read(tokenRefreshCallbackProvider);
+        final refreshResult = await refreshCallback();
+
+        // 自前のリフレッシュAPIが正しく叩かれていること
+        check(refreshResult).isTrue();
+        verify(mockAuthRepository.refreshToken).called(1);
+      },
+    );
+  });
+}

--- a/test/src/features/auth/data/auth_integration_test.dart
+++ b/test/src/features/auth/data/auth_integration_test.dart
@@ -4,11 +4,10 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_sample/src/core/network/token_interceptor.dart';
 import 'package:flutter_sample/src/core/storage/secure_storage_provider.dart';
-import 'package:flutter_sample/src/core/storage/token_storage.dart';
 import 'package:flutter_sample/src/core/utils/logger_provider.dart';
+import 'package:flutter_sample/src/features/auth/data/auth_overrides.dart';
 import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
 import 'package:flutter_sample/src/features/auth/data/firebase_auth_repository.dart';
-import 'package:flutter_sample/src/features/auth/data/firebase_auth_token_storage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -61,29 +60,8 @@ void main() {
                 useFirebaseAuth: true,
               ),
             ),
-            // 2. TokenStorageを Firebase 用に上書き
-            tokenStorageProvider.overrideWith((ref) {
-              return FirebaseAuthTokenStorage(ref.watch(firebaseAuthProvider));
-            }),
-            // 3. リフレッシュコールバックを Firebase 用に上書き
-            tokenRefreshCallbackProvider.overrideWith((ref) {
-              final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
-              if (useFirebase) {
-                return () async {
-                  try {
-                    final user = ref.read(firebaseAuthProvider).currentUser;
-                    if (user != null) {
-                      final token = await user.getIdToken(true);
-                      return token != null;
-                    }
-                    return false;
-                  } on Exception catch (_) {
-                    return false;
-                  }
-                };
-              }
-              return ref.read(authRepositoryProvider).refreshToken;
-            }),
+            // 2. 共通の認証オーバーライドを適用
+            ...getAuthOverrides().cast(),
             firebaseAuthProvider.overrideWithValue(mockFirebaseAuth),
             loggerProvider.overrideWithValue(talker),
           ],
@@ -135,27 +113,10 @@ void main() {
                 useFirebaseAuth: false,
               ),
             ),
-            // 2. TokenStorage は上書きせずデフォルトのまま（SecureStorageを使用）
+            // 2. 共通の認証オーバーライドを適用
+            ...getAuthOverrides().cast(),
+            // 3. SecureStorageはテスト用のモックで上書き
             secureStorageProvider.overrideWithValue(mockSecureStorage),
-            // 3. リフレッシュコールバックを 自前サーバーAPI に上書き
-            tokenRefreshCallbackProvider.overrideWith((ref) {
-              final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
-              if (useFirebase) {
-                return () async {
-                  try {
-                    final user = ref.read(firebaseAuthProvider).currentUser;
-                    if (user != null) {
-                      final token = await user.getIdToken(true);
-                      return token != null;
-                    }
-                    return false;
-                  } on Exception catch (_) {
-                    return false;
-                  }
-                };
-              }
-              return ref.read(authRepositoryProvider).refreshToken;
-            }),
             authRepositoryProvider.overrideWithValue(mockAuthRepository),
             loggerProvider.overrideWithValue(talker),
           ],
@@ -180,6 +141,43 @@ void main() {
         // 自前のリフレッシュAPIが正しく叩かれていること
         check(refreshResult).isTrue();
         verify(mockAuthRepository.refreshToken).called(1);
+      },
+    );
+
+    test(
+      '【useFirebaseAuth: true】 の際、IDトークン更新時に例外が発生した場合に、'
+      ' リフレッシュコールバックが false を返すこと',
+      () async {
+        final mockFirebaseAuth = MockFirebaseAuth();
+        final mockUser = MockUser();
+
+        when(() => mockFirebaseAuth.currentUser).thenReturn(mockUser);
+        when(
+          () => mockUser.getIdToken(true),
+        ).thenThrow(FirebaseAuthException(code: 'test-error'));
+
+        final container = ProviderContainer(
+          overrides: [
+            envConfigProvider.overrideWithValue(
+              const EnvConfigState(
+                baseUrl: 'https://example.com',
+                aiModel: 'gemini-2.5-flash',
+                connectTimeout: 10,
+                receiveTimeout: 15,
+                sendTimeout: 10,
+                useFirebaseAuth: true,
+              ),
+            ),
+            ...getAuthOverrides().cast(),
+            firebaseAuthProvider.overrideWithValue(mockFirebaseAuth),
+            loggerProvider.overrideWithValue(talker),
+          ],
+        );
+
+        final refreshCallback = container.read(tokenRefreshCallbackProvider);
+        final refreshResult = await refreshCallback();
+
+        check(refreshResult).isFalse();
       },
     );
   });

--- a/test/src/features/auth/data/firebase_auth_token_storage_test.dart
+++ b/test/src/features/auth/data/firebase_auth_token_storage_test.dart
@@ -1,0 +1,63 @@
+import 'package:checks/checks.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_sample/src/features/auth/data/firebase_auth_token_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+
+class MockUser extends Mock implements User {}
+
+void main() {
+  late MockFirebaseAuth mockFirebaseAuth;
+  late MockUser mockUser;
+  late FirebaseAuthTokenStorage tokenStorage;
+
+  setUp(() {
+    mockFirebaseAuth = MockFirebaseAuth();
+    mockUser = MockUser();
+    tokenStorage = FirebaseAuthTokenStorage(mockFirebaseAuth);
+  });
+
+  group('FirebaseAuthTokenStorage', () {
+    test('getAccessToken: ユーザーがログイン状態の時、最新のIDトークンを返すこと', () async {
+      when(() => mockFirebaseAuth.currentUser).thenReturn(mockUser);
+      when(
+        () => mockUser.getIdToken(),
+      ).thenAnswer((_) async => 'dummy_id_token');
+
+      final token = await tokenStorage.getAccessToken();
+
+      check(token).equals('dummy_id_token');
+      verify(() => mockFirebaseAuth.currentUser).called(1);
+      verify(() => mockUser.getIdToken()).called(1);
+    });
+
+    test('getAccessToken: ユーザーが未ログイン状態の時、nullを返すこと', () async {
+      when(() => mockFirebaseAuth.currentUser).thenReturn(null);
+
+      final token = await tokenStorage.getAccessToken();
+
+      check(token).isNull();
+      verify(() => mockFirebaseAuth.currentUser).called(1);
+    });
+
+    test('getRefreshToken: 常にnullを返すこと', () async {
+      final token = await tokenStorage.getRefreshToken();
+      check(token).isNull();
+    });
+
+    test('saveTokens: 何も処理を行わないこと', () async {
+      await check(
+        tokenStorage.saveTokens(
+          accessToken: 'dummy_access',
+          refreshToken: 'dummy_refresh',
+        ),
+      ).completes();
+    });
+
+    test('clear: 何も処理を行わないこと', () async {
+      await check(tokenStorage.clear()).completes();
+    });
+  });
+}

--- a/test/src/features/auth/data/firebase_auth_token_storage_test.dart
+++ b/test/src/features/auth/data/firebase_auth_token_storage_test.dart
@@ -56,8 +56,12 @@ void main() {
       ).completes();
     });
 
-    test('clear: 何も処理を行わないこと', () async {
+    test('clear: Firebase Auth の signOut が実行されること', () async {
+      when(() => mockFirebaseAuth.signOut()).thenAnswer((_) async {});
+
       await check(tokenStorage.clear()).completes();
+
+      verify(() => mockFirebaseAuth.signOut()).called(1);
     });
   });
 }


### PR DESCRIPTION
## 📝 概要

- FirebaseAuthTokenStorageを新規作成し、FirebaseのIDトークン取得処理をカプセル化
- main.dartのProviderContainerのオーバーライド（overrideWith）内でref.watch(envConfigProvider)を監視し、useFirebaseAuthフラグに応じて動的にトークン処理を切り替えるように実装（起動後の上書き数変更不可によるクラッシュを防止）
- package:checks と mocktail を使用したFirebaseAuthTokenStorageの単体テストを新規追加し、カバレッジ100%を維持
- docs/auth.md および docs/firebase_authentication.md に最新の実装仕様と自動切り替えの仕組みを追記

## ✅ 確認事項

- [x] AIによるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューは、プルリクエストの作成時（※下書き/ドラフト状態を除く）および、公開後のプルリクエストに新しいコミットが追加（プッシュ）されたタイミングで自動実行されます。
  - **下書き（ドラフト）状態では自動実行されません。** 下書きの状態でレビューを動かしたい場合や、手動で再実行したい場合は、プルリクエストのコメント欄で `@coderabbitai review` と入力してください。
  - コメント欄で以下のコマンドを使用し、CodeRabbitの動きをコントロールできます：
    - `@coderabbitai review` : 新しく追加された変更箇所（差分）だけをレビューします。
    - `@coderabbitai full review` : プルリクエスト全体のプログラムを最初からレビューし直します。
    - `@coderabbitai pause` : 自動レビューを一時停止します。
    - `@coderabbitai resume` : 自動レビューを再開します。

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)

## ❕ 関連するIssue

Closes #168 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 環境設定に応じて認証方式を自動切り替えし、API 呼び出し時に `Authorization: Bearer <トークン>` を自動付与します（Firebase/非Firebase両対応）。
  * 401 の場合はトークンを強制更新し、必要に応じてリクエストをリトライします。
* **Documentation**
  * Firebase Auth モードでのトークン取得・リフレッシュ手順と API 統合内容を追記しました。
* **Tests**
  * Firebase 用トークンストレージの挙動、ヘッダー付与・更新経路の統合テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->