### PR TITLE
refactor(test): テストのアサーションを expect から package:checks に移行

### DIFF
--- a/test/src/features/profile/presentation/profile_edit_screen_test.dart
+++ b/test/src/features/profile/presentation/profile_edit_screen_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_sample/l10n/app_localizations.dart';
 import 'package:flutter_sample/src/core/exceptions/app_exception.dart';
@@ -113,7 +114,7 @@ void main() {
 
       await tester.pumpWidget(createTestWidget(container: container));
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      check(find.byType(CircularProgressIndicator)).findsOne();
     });
 
     testWidgets('初期表示：UserProfileの各値が正しくバインドされていること', (tester) async {
@@ -154,7 +155,7 @@ void main() {
       await tester.pumpWidget(createTestWidget(container: container));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('読み込み失敗'), findsOneWidget);
+      check(find.textContaining('読み込み失敗')).findsOne();
 
       shouldFail = false;
 
@@ -221,15 +222,15 @@ void main() {
       await tester.pumpAndSettle();
 
       // エラー文言が表示されること
-      expect(find.text('氏名は必須入力です'), findsOneWidget);
-      expect(find.text('有効なメールアドレス形式で入力してください'), findsOneWidget);
+      check(find.text('氏名は必須入力です')).findsOne();
+      check(find.text('有効なメールアドレス形式で入力してください')).findsOne();
 
       // 2. 氏名に空白スペースのみを入力した場合のテスト
       await tester.enterText(nameFinder, '   '); // 空白スペースのみ
       await tester.pump();
       await tester.tap(find.text('保存する'));
       await tester.pumpAndSettle();
-      expect(find.text('氏名に空白のみを入力することはできません'), findsOneWidget);
+      check(find.text('氏名に空白のみを入力することはできません')).findsOne();
     });
 
     testWidgets('バリデーション：電話番号の桁数チェックが正しく動くこと', (tester) async {
@@ -252,14 +253,14 @@ void main() {
       await tester.pump();
       await tester.tap(find.text('保存する'));
       await tester.pumpAndSettle();
-      expect(find.text('携帯電話・IP電話は11桁で入力してください'), findsOneWidget);
+      check(find.text('携帯電話・IP電話は11桁で入力してください')).findsOne();
 
       // 2. 固定電話等 (03で始まる) なのに11桁の場合
       await tester.enterText(phoneFinder, '03123456789'); // 11桁
       await tester.pump();
       await tester.tap(find.text('保存する'));
       await tester.pumpAndSettle();
-      expect(find.text('固定電話等は10桁で入力してください'), findsOneWidget);
+      check(find.text('固定電話等は10桁で入力してください')).findsOne();
 
       // 3. 非数字が含まれる場合のテスト (Formatterをバイパスして直接テキストを代入)
       final phoneField = tester.widget<TextFormField>(phoneFinder);
@@ -267,7 +268,7 @@ void main() {
       await tester.pump();
       await tester.tap(find.text('保存する'));
       await tester.pumpAndSettle();
-      expect(find.text('半角数字のみで入力してください'), findsOneWidget);
+      check(find.text('半角数字のみで入力してください')).findsOne();
     });
 
     testWidgets('保存：正常に入力し、保存に成功した際、スナックバーが表示されること', (tester) async {
@@ -298,7 +299,7 @@ void main() {
       await tester.pump(); // スナックバー表示のアニメーション開始
 
       // SnackBar が表示されていること
-      expect(find.text('会員情報を保存しました'), findsOneWidget);
+      check(find.text('会員情報を保存しました')).findsOne();
       check(updateCalled).isTrue();
     });
 
@@ -329,7 +330,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // エラーハンドラー経由の SnackBar が表示されていること
-      expect(find.text('通信エラー'), findsOneWidget);
+      check(find.text('通信エラー')).findsOne();
     });
 
     testWidgets('保存：保存中はフォームが維持され、フルスクリーンスピナーが表示されないこと', (tester) async {


### PR DESCRIPTION
## 📝 概要

- `profile_edit_screen_test.dart` 内の 10 箇所の `expect(..., findsOneWidget)` を `check(...).findsOne()` に書き換え
- UI要素の検証用として `package:flutter_checks` をインポートに追加
- 静的解析エラー（directives_ordering）を解消するため、インポート文をアルファベット順に整理

## ✅ 確認事項

- [x] AIによるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューは、プルリクエストの作成時（※下書き/ドラフト状態を除く）および、公開後のプルリクエストに新しいコミットが追加（プッシュ）されたタイミングで自動実行されます。
  - **下書き（ドラフト）状態では自動実行されません。** 下書きの状態でレビューを動かしたい場合や、手動で再実行したい場合は、プルリクエストのコメント欄で `@coderabbitai review` と入力してください。
  - コメント欄で以下のコマンドを使用し、CodeRabbitの動きをコントロールできます：
    - `@coderabbitai review` : 新しく追加された変更箇所（差分）だけをレビューします。
    - `@coderabbitai full review` : プルリクエスト全体のプログラムを最初からレビューし直します。
    - `@coderabbitai pause` : 自動レビューを一時停止します。
    - `@coderabbitai resume` : 自動レビューを再開します。

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)

## ❕ 関連するIssue

Closes #173 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * ウィジェットテストのアサーション表記を更新し、より一貫した検証方法に統一しました。
  * ローディング表示、エラー文言、入力バリデーション、保存成功/失敗時の表示確認を維持したまま、検証の読みやすさを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->