### PR TITLE
test: E2Eテスト(Maestro)のアプリロック解錠フロー追加とストレージモックの堅牢化 (#197)

### DIFF
--- a/docs/app_lock.md
+++ b/docs/app_lock.md
@@ -99,3 +99,4 @@ stateDiagram-v2
 - **単体テスト**: `test/src/features/app_lock/data/app_lock_repository_test.dart`, `app_lock_service_test.dart`
 - **ウィジェットテスト**: `passcode_setup_screen_test.dart`, `passcode_lock_screen_test.dart`, `app_lock_wrapper_test.dart`, `numeric_keyboard_test.dart`
 - **ゴールデンテスト**: `app_lock_golden_test.dart` (`alchemist` によるライト/ダークモード描画検証)
+- **E2Eテスト (Maestro)**: `maestro/app_lock_flow.yaml` (ログイン後の初期パスコード登録、アプリ復帰時の自動再ロック、およびパスコード入力によるロック解除フローの自動検証)

--- a/docs/e2e_testing_maestro.md
+++ b/docs/e2e_testing_maestro.md
@@ -21,13 +21,12 @@
 3. **E2E専用の起動設定 (`lib/main_e2e.dart`)**
    - **認証と通信のモック**: Firebase Auth を無効化し、ネットワーク状態をオフラインに固定（通信を遮断）して不要なAPI接続が発生しないよう Riverpod プロバイダを上書きしています。
    - **アプリアプデ判定のバイパス**: テスト中に不要な「最新版への更新」ダイアログが出ないようにしています。
-   - **ログイン状態の自動初期化**: iOSの仕様上、アプリを再起動してもキーチェーン（SecureStorage）にログイン用のトークンが残り続けてしまうため、起動スイッチが入る直前にトークンを自動クリアしています。
+   - **暗号化ストレージのモック (`FakeSecureStorage`)**: iOSシミュレータのキーチェーン制限やプロセス再起動に左右されずトークン・パスコードを保持できるよう、一時ファイル (`Directory.systemTemp`) を使って安全かつ確実に状態を管理・復元するフェイクストレージを注入しています。
+   - **生体認証のモック固定**: E2Eテスト中、OSの生体認証（Face ID / Touch ID）ダイアログによってテストが中断・ブレるのを防ぐため、`localAuthenticationProvider` を「利用不可 (`canCheckBiometrics = false`)」として固定しています。
 
 ---
 
 ## 🛠️ テストの実行手順
-
-E2Eテストを実行する手順は以下の通りです。
 
 ### 1. iOSシミュレータの起動
 
@@ -52,7 +51,11 @@ fvm flutter run --flavor local -t lib/main_e2e.dart --dart-define-from-file conf
 別のターミナルを開き、定義したテストフロー（YAMLファイル）を実行します。
 
 ```bash
+# 基本ログインフローの検証
 ~/.maestro/bin/maestro test maestro/app_launch_and_login.yaml
+
+# アプリロック機能（設定・アプリ復帰・パスコード解錠）の検証
+~/.maestro/bin/maestro test maestro/app_lock_flow.yaml
 ```
 
 ※テストが走り、全てのステップが「COMPLETED」になれば成功です。
@@ -61,6 +64,8 @@ fvm flutter run --flavor local -t lib/main_e2e.dart --dart-define-from-file conf
 
 ## 📂 テストシナリオの構成
 
-テストフローは [maestro/app_launch_and_login.yaml](../maestro/app_launch_and_login.yaml) で管理されています。
+テストフローは `maestro/` ディレクトリ配下で管理されています。
 
+- **[maestro/app_launch_and_login.yaml](../maestro/app_launch_and_login.yaml)**: 起動 $\rightarrow$ オンボーディングスキップ $\rightarrow$ ログイン $\rightarrow$ 4桁パスコード初期登録 (`1234` + `1234`) $\rightarrow$ ホーム表示までの基本最短フローを検証。
+- **[maestro/app_lock_flow.yaml](../maestro/app_lock_flow.yaml)**: ログイン＆パスコード登録後、生体認証プロンプト閉じに伴う誤ロック防止ロジック (`_shouldSkipNextLock`) の挙動を踏まえ、バックグラウンド復帰動作 (`pressKey: Home` $\rightarrow$ `launchApp`) により自動表示されるロック画面 (`PasscodeLockScreen`) を 4桁パスコード (`1234`) で解除するリアルなアプリロック解錠テスト。
 - iOSのアクセシビリティ仕様（ラベルの改行結合）に対応するため、入力フィールドのタップなどには正規表現（regex）を用いて確実に要素を検出する工夫をしています。

--- a/lib/main_e2e.dart
+++ b/lib/main_e2e.dart
@@ -1,13 +1,105 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_sample/main.dart';
 import 'package:flutter_sample/src/core/config/env_config.dart';
 import 'package:flutter_sample/src/core/config/flavor_provider.dart';
 import 'package:flutter_sample/src/core/config/update_request_provider.dart';
 import 'package:flutter_sample/src/core/network/api_client.dart';
+import 'package:flutter_sample/src/core/storage/secure_storage_provider.dart';
 import 'package:flutter_sample/src/core/utils/connectivity_provider.dart';
+import 'package:flutter_sample/src/features/app_lock/data/local_authentication_provider.dart';
 import 'package:flutter_sample/src/features/auth/data/auth_repository.dart';
 import 'package:flutter_sample/src/features/auth/data/token_storage.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:local_auth/local_auth.dart';
+
+/// E2Eテスト用に一時ファイル上で安全に Key-Value を保存・復元する SecureStorage フェイク
+class FakeSecureStorage extends FlutterSecureStorage {
+  static final File _file = File(
+    '${Directory.systemTemp.path}/e2e_secure_storage.json',
+  );
+
+  Map<String, String> _readStorage() {
+    try {
+      if (_file.existsSync()) {
+        final content = _file.readAsStringSync();
+        final decoded = jsonDecode(content);
+        if (decoded is Map) {
+          return Map<String, String>.from(decoded);
+        }
+      }
+    } on Exception catch (_) {}
+    return {};
+  }
+
+  void _writeStorage(Map<String, String> data) {
+    try {
+      _file.writeAsStringSync(jsonEncode(data));
+    } on Exception catch (_) {}
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    final storage = _readStorage();
+    if (value == null) {
+      storage.remove(key);
+    } else {
+      storage[key] = value;
+    }
+    _writeStorage(storage);
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    final storage = _readStorage();
+    return storage[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    final storage = _readStorage()..remove(key);
+    _writeStorage(storage);
+  }
+
+  @override
+  Future<void> deleteAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _writeStorage({});
+  }
+}
 
 /// E2Eテスト用にモック化した認証リポジトリ
 class MockAuthRepository implements AuthRepository {
@@ -44,19 +136,26 @@ class FakeUpdateRequestController extends UpdateRequestController {
   }
 }
 
+/// E2Eテスト用に常に生体認証非対応（canCheckBiometrics = false）として振る舞うフェイククラス
+class FakeLocalAuthentication extends LocalAuthentication {
+  @override
+  Future<bool> get canCheckBiometrics async => false;
+
+  @override
+  Future<bool> isDeviceSupported() async => false;
+}
+
 Future<void> main() async {
   // Flutterのシステム初期化
   WidgetsFlutterBinding.ensureInitialized();
 
-  // E2Eテスト開始前に古いキーチェーン（SecureStorage）のトークンを強制消去する
-  final container = ProviderContainer();
-  final tokenStorage = container.read(tokenStorageProvider);
-  await tokenStorage.clear();
-  container.dispose();
+  final fakeStorage = FakeSecureStorage();
 
   await mainCommon(
     Flavor.local,
     additionalOverrides: [
+      // 0. セキュアストレージをファイルベースのフェイクに置き換え (プロセス再起動後も状態維持)
+      secureStorageProvider.overrideWithValue(fakeStorage),
       // 1. Firebase Auth を無効化し、通常のログインフロー（API通信）として動作させる設定
       envConfigProvider.overrideWith((ref) {
         return const EnvConfigState(
@@ -79,6 +178,10 @@ Future<void> main() async {
       // 4. アップデート要求を「なし」に固定
       updateRequestControllerProvider.overrideWith(
         FakeUpdateRequestController.new,
+      ),
+      // 5. 生体認証を「利用不可」に固定してテストを安定化
+      localAuthenticationProvider.overrideWithValue(
+        FakeLocalAuthentication(),
       ),
     ],
   );

--- a/lib/main_e2e.dart
+++ b/lib/main_e2e.dart
@@ -22,22 +22,19 @@ class FakeSecureStorage extends FlutterSecureStorage {
   );
 
   Map<String, String> _readStorage() {
-    try {
-      if (_file.existsSync()) {
-        final content = _file.readAsStringSync();
-        final decoded = jsonDecode(content);
-        if (decoded is Map) {
-          return Map<String, String>.from(decoded);
-        }
-      }
-    } on Exception catch (_) {}
+    if (!_file.existsSync()) {
+      return {};
+    }
+    final content = _file.readAsStringSync();
+    final decoded = jsonDecode(content);
+    if (decoded is Map) {
+      return Map<String, String>.from(decoded);
+    }
     return {};
   }
 
   void _writeStorage(Map<String, String> data) {
-    try {
-      _file.writeAsStringSync(jsonEncode(data));
-    } on Exception catch (_) {}
+    _file.writeAsStringSync(jsonEncode(data));
   }
 
   @override

--- a/lib/main_e2e.dart
+++ b/lib/main_e2e.dart
@@ -140,6 +140,9 @@ class FakeLocalAuthentication extends LocalAuthentication {
 
   @override
   Future<bool> isDeviceSupported() async => false;
+
+  @override
+  Future<List<BiometricType>> getAvailableBiometrics() async => [];
 }
 
 Future<void> main() async {

--- a/maestro/app_launch_and_login.yaml
+++ b/maestro/app_launch_and_login.yaml
@@ -2,7 +2,15 @@ appId: jp.example.sample.local
 ---
 - launchApp:
     clearState: true
+
+# オンボーディング画面のスキップボタン描画を待機してからタップ
+- assertVisible: "スキップ"
 - tapOn: "スキップ"
+
+# ログイン画面の切り替え表示を待機
+- assertVisible:
+    text: ".*メールアドレス.*"
+
 - tapOn:
     text: ".*メールアドレス.*"
 - inputText: "test@example.com"
@@ -10,4 +18,26 @@ appId: jp.example.sample.local
     text: ".*パスワード.*"
 - inputText: "password123"
 - tapOn: "ログイン実行ボタン"
+
+# パスコード初期設定画面の表示を待機
+- assertVisible:
+    text: ".*パスコード.*"
+
+- tapOn:
+    text: "1"
+- tapOn:
+    text: "2"
+- tapOn:
+    text: "3"
+- tapOn:
+    text: "4"
+- tapOn:
+    text: "1"
+- tapOn:
+    text: "2"
+- tapOn:
+    text: "3"
+- tapOn:
+    text: "4"
+
 - assertVisible: "現在の環境"

--- a/maestro/app_lock_flow.yaml
+++ b/maestro/app_lock_flow.yaml
@@ -1,0 +1,73 @@
+appId: jp.example.sample.local
+---
+- launchApp:
+    clearState: true
+
+# オンボーディング画面のスキップボタン描画を待機してからタップ
+- assertVisible: "スキップ"
+- tapOn: "スキップ"
+
+# ログイン画面の切り替え表示を待機
+- assertVisible:
+    text: ".*メールアドレス.*"
+
+- tapOn:
+    text: ".*メールアドレス.*"
+- inputText: "test@example.com"
+- tapOn:
+    text: ".*パスワード.*"
+- inputText: "password123"
+- tapOn: "ログイン実行ボタン"
+
+# パスコード初期設定画面の表示を待機
+- assertVisible:
+    text: ".*パスコード.*"
+
+# 4桁の初期パスコード設定 (1234)
+- tapOn:
+    text: "1"
+- tapOn:
+    text: "2"
+- tapOn:
+    text: "3"
+- tapOn:
+    text: "4"
+
+# 4桁の確認用パスコード再入力 (1234)
+- tapOn:
+    text: "1"
+- tapOn:
+    text: "2"
+- tapOn:
+    text: "3"
+- tapOn:
+    text: "4"
+
+# 初期設定が完了しホーム画面が表示されることをアサート
+- assertVisible: "現在の環境"
+
+# -------------------------------------------------------------
+# 🔒 【バックグラウンド復帰とロック解錠のテスト】
+# -------------------------------------------------------------
+# 1. 1回目の復帰操作 (生体認証プロンプト保護フラグ _shouldSkipNextLock を消費)
+- pressKey: Home
+- launchApp
+
+# 2. 2回目の復帰操作 (アプリロック AppLockStateLocked が正常発火)
+- pressKey: Home
+- launchApp
+
+# 3. 最前面に自動表示されたロック画面の確認と 1234 による解錠
+- assertVisible:
+    text: ".*パスコード.*"
+- tapOn:
+    text: "1"
+- tapOn:
+    text: "2"
+- tapOn:
+    text: "3"
+- tapOn:
+    text: "4"
+
+# 4. ロック解除後、ホーム画面が表示されることを検証
+- assertVisible: "現在の環境"

--- a/maestro/app_lock_flow.yaml
+++ b/maestro/app_lock_flow.yaml
@@ -51,11 +51,13 @@ appId: jp.example.sample.local
 # -------------------------------------------------------------
 # 1. 1回目の復帰操作 (生体認証プロンプト保護フラグ _shouldSkipNextLock を消費)
 - pressKey: Home
-- launchApp
+- launchApp:
+    stopApp: false
 
 # 2. 2回目の復帰操作 (アプリロック AppLockStateLocked が正常発火)
 - pressKey: Home
-- launchApp
+- launchApp:
+    stopApp: false
 
 # 3. 最前面に自動表示されたロック画面の確認と 1234 による解錠
 - assertVisible:


### PR DESCRIPTION
## 📝 概要

iOSシミュレータ環境におけるプロセス再起動やMaestro自動テストの安定化を図るため、E2Eテスト環境およびアプリロックのテストシナリオを拡充・最適化しました。

【変更内容】
- lib/main_e2e.dart:
  - iOSシミュレータのKeyChain権限やプロセス再起動(launchApp)に影響を受けないよう、一時ファイル(Directory.systemTemp)を利用してトークン・パスコードを安全に保持・復元する FakeSecureStorage を実装し、Riverpod プロバイダへ注入。
  - 生体認証を「利用不可(canCheckBiometrics = false)」にモック固定する FakeLocalAuthentication を追加。
- maestro/app_launch_and_login.yaml:
  - オンボーディング・ログイン直後のUI描画待機 (assertVisible) ステップを補強。
- maestro/app_lock_flow.yaml:
  - ログイン〜初期パスコード設定〜バックグラウンド復帰〜パスコード(1234)入力による解錠フローを自動検証するシナリオを新規作成。
- docs/e2e_testing_maestro.md & docs/app_lock.md:
  - E2Eテストの最新仕様(ファイルベースFakeSecureStorage)および実行手順ドキュメントを更新。

## ✅ 確認事項

- [x] AIによるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューは、プルリクエストの作成時（※下書き/ドラフト状態を除く）および、公開後のプルリクエストに新しいコミットが追加（プッシュ）されたタイミングで自動実行されます。
  - **下書き（ドラフト）状態では自動実行されません。** 下書きの状態でレビューを動かしたい場合や、手動で再実行したい場合は、プルリクエストのコメント欄で `@coderabbitai review` と入力してください。
  - コメント欄で以下のコマンドを使用し、CodeRabbitの動きをコントロールできます：
    - `@coderabbitai review` : 新しく追加された変更箇所（差分）だけをレビューします。
    - `@coderabbitai full review` : プルリクエスト全体のプログラムを最初からレビューし直します。
    - `@coderabbitai pause` : 自動レビューを一時停止します。
    - `@coderabbitai resume` : 自動レビューを再開します。

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)

## ❕ 関連するIssue

Closes #197


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ログイン後の初回パスコード登録と、パスコードによるアプリロック解除フローを追加しました。
  * アプリをバックグラウンドから復帰した際の自動再ロックを確認できるようになりました。

* **テスト**
  * ログイン、オンボーディング、パスコード設定、アプリロック解除を含むE2Eテストを追加しました。
  * 安定したテスト実行のため、ストレージと生体認証のテスト用環境を整備しました。

* **ドキュメント**
  * E2Eテストの構成、実行手順、アプリロックシナリオを追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->