### PR TITLE
fix(app_lock): AIチャット送信時・一時非活性時のアプリ誤ロック防止 (#204)

### DIFF
--- a/docs/app_lock.md
+++ b/docs/app_lock.md
@@ -51,7 +51,7 @@ stateDiagram-v2
 
     setupRequired --> unlocked: パスコード設定完了
     locked --> unlocked: パスコード一致 OR 生体認証成功
-    unlocked --> locked: バックグラウンド復帰 (paused/hidden -> resumed)
+    unlocked --> locked: バックグラウンド復帰 (paused/hidden -> [inactive] -> resumed)
     unlocked --> disabled: ログアウト (認証状態変更)
     setupRequired --> disabled: clearAppLock (設定全削除)
     locked --> disabled: clearAppLock (設定全削除)
@@ -87,7 +87,8 @@ stateDiagram-v2
 
 ### アプリ内一時非活性・OS 生体認証ダイアログの誤ロック防止設計
 
-- **真のバックグラウンド判定**: `AppLockWrapper` は直前の状態が `paused` または `hidden` であった場合のみ `lockApp()` を呼び出します。チャット送信時やキーボード開閉、Firebase ネットワーク通信等に伴う一瞬の非活性状態（`inactive` $\rightarrow$ `resumed`）では誤ロックが発生しません。
+- **バックグラウンド履歴追跡**: `AppLockWrapper` は内部フラグ (`hasSeenBackground`) で `paused` または `hidden` 状態の通過を追跡します。OS によって `paused` $\rightarrow$ `inactive` $\rightarrow$ `resumed` の順でイベントが通知される場合でも確実に復帰を検知して `lockApp()` を呼び出します。
+- **一時非活性の分離**: チャット送信時やキーボード開閉、Firebase ネットワーク通信等に伴う単なる一時非活性状態（`resumed` $\rightarrow$ `inactive` $\rightarrow$ `resumed`）ではバックグラウンド通過フラグが `false` のため誤ロックが発生しません。
 - **生体認証排他制御**: 生体認証実行中（Face ID ダイアログ表示中）は、OS から発行される `resumed` イベントによる二重ロックを防ぐため `_isAuthenticating` フラグで排他制御しています。
 - **初回復帰のスキップ制御**: OS の生体認証プロンプト閉じに伴い発生する復帰イベントのみを `_shouldSkipNextLock` で追跡・初回消費することで誤ロックを防ぎ、手動によるアプリ復帰時は即座に再ロックされるよう制御しています。
 

--- a/docs/app_lock.md
+++ b/docs/app_lock.md
@@ -51,7 +51,7 @@ stateDiagram-v2
 
     setupRequired --> unlocked: パスコード設定完了
     locked --> unlocked: パスコード一致 OR 生体認証成功
-    unlocked --> locked: バックグラウンド復帰 (resumed)
+    unlocked --> locked: バックグラウンド復帰 (paused/hidden -> resumed)
     unlocked --> disabled: ログアウト (認証状態変更)
     setupRequired --> disabled: clearAppLock (設定全削除)
     locked --> disabled: clearAppLock (設定全削除)
@@ -60,7 +60,7 @@ stateDiagram-v2
 
 1. **`disabled`**: 未ログイン状態。ロック機能は無効。
 2. **`setupRequired`**: ログイン済みだがパスコードが未登録。アプリ起動時に初期設定画面を表示。
-3. **`locked`**: パスコード登録済み。起動時・復帰時にロック画面を表示。
+3. **`locked`**: パスコード登録済み。起動時・バックグラウンド復帰時にロック画面を表示。
 4. **`unlocked`**: 正しいパスコード入力または生体認証成功により一時的にロック解除された状態。
 
 > 💡 **ログアウトと `clearAppLock()` の違い**
@@ -85,10 +85,11 @@ stateDiagram-v2
 - ロックアウト期間中の試行は、暗号化ストレージへの照合（`verifyPasscode`）を行わずに即座に拒否されます。
 - パスコード認証成功時または `clearAppLock()` 実行時に、失敗カウントおよびロックアウト状態は Secure Storage から自動リセットされます。
 
-### OS 生体認証ダイアログの遅延・復帰保護
+### アプリ内一時非活性・OS 生体認証ダイアログの誤ロック防止設計
 
-- 生体認証実行中（Face ID ダイアログ表示中）は、OS から発行される `resumed` イベントによる二重ロックを防ぐため `_isAuthenticating` フラグで排他制御しています。
-- OS の生体認証プロンプト閉じに伴い発生する復帰イベントのみを `_promptDismissedAt` で追跡・初回消費することで誤ロックを防ぎ、手動によるアプリ復帰時は即座に再ロックされるよう制御しています。
+- **真のバックグラウンド判定**: `AppLockWrapper` は直前の状態が `paused` または `hidden` であった場合のみ `lockApp()` を呼び出します。チャット送信時やキーボード開閉、Firebase ネットワーク通信等に伴う一瞬の非活性状態（`inactive` $\rightarrow$ `resumed`）では誤ロックが発生しません。
+- **生体認証排他制御**: 生体認証実行中（Face ID ダイアログ表示中）は、OS から発行される `resumed` イベントによる二重ロックを防ぐため `_isAuthenticating` フラグで排他制御しています。
+- **初回復帰のスキップ制御**: OS の生体認証プロンプト閉じに伴い発生する復帰イベントのみを `_shouldSkipNextLock` で追跡・初回消費することで誤ロックを防ぎ、手動によるアプリ復帰時は即座に再ロックされるよう制御しています。
 
 ---
 

--- a/lib/src/features/app_lock/application/app_lock_service.dart
+++ b/lib/src/features/app_lock/application/app_lock_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter_sample/src/features/app_lock/data/app_lock_repository.da
 import 'package:flutter_sample/src/features/app_lock/domain/app_lock_state.dart';
 import 'package:flutter_sample/src/features/auth/application/auth_state_notifier.dart';
 import 'package:flutter_sample/src/features/auth/application/firebase_auth_state_notifier.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'app_lock_service.g.dart';
@@ -32,12 +33,20 @@ class AppLockService extends _$AppLockService {
   @override
   Future<AppLockState> build() async {
     final talker = ref.watch(loggerProvider);
-    final useFirebase = ref.watch(envConfigProvider).useFirebaseAuth;
+    final useFirebase = ref.watch(
+      envConfigProvider.select((c) => c.useFirebaseAuth),
+    );
 
     // 認証状態の監視 (ログイン中かどうか判定)
+    // select を使って「ログイン中かどうか (bool)」の変更のみを監視し、
+    // トークン更新等による不要な build() の再実行・誤ロックを防止する
     final isAuthenticated = useFirebase
-        ? ref.watch(firebaseAuthStateProvider).value != null
-        : ref.watch(authStateProvider).value == true;
+        ? ref.watch(
+            firebaseAuthStateProvider.select((s) => s.value != null),
+          )
+        : ref.watch(
+            authStateProvider.select((s) => s.value == true),
+          );
 
     talker.debug('[AppLockService] build (isAuthenticated: $isAuthenticated)');
 

--- a/lib/src/features/app_lock/application/app_lock_service.g.dart
+++ b/lib/src/features/app_lock/application/app_lock_service.g.dart
@@ -36,7 +36,7 @@ final class AppLockServiceProvider
   AppLockService create() => AppLockService();
 }
 
-String _$appLockServiceHash() => r'4117aae9a9fd55cf913c9193287a7a0773c67f2b';
+String _$appLockServiceHash() => r'428af22162941f969eaa9a7ccb6a97a2c048b55b';
 
 /// 🔐 アプリロックのロジックと状態（sealed クラス）を管理する AsyncNotifier
 

--- a/lib/src/features/app_lock/presentation/app_lock_wrapper.dart
+++ b/lib/src/features/app_lock/presentation/app_lock_wrapper.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_sample/src/core/utils/app_lifecycle_provider.dart';
 import 'package:flutter_sample/src/features/app_lock/application/app_lock_service.dart';
 import 'package:flutter_sample/src/features/app_lock/domain/app_lock_state.dart';
@@ -7,7 +8,7 @@ import 'package:flutter_sample/src/features/app_lock/presentation/passcode_setup
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// 🔐 アプリ全体を包み込み、最前面にロックオーバーレイを描画＆ライフサイクル監視を行うラッパー
-class AppLockWrapper extends ConsumerWidget {
+class AppLockWrapper extends HookConsumerWidget {
   /// コンストラクタ
   const AppLockWrapper({
     required this.child,
@@ -21,14 +22,19 @@ class AppLockWrapper extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final appLockAsync = ref.watch(appLockServiceProvider);
 
-    // アプリのライフサイクル（バックグラウンド復帰）監視
-    ref.listen(appLifecycleProvider, (previous, next) {
-      final cameFromBackground =
-          previous == AppLifecycleState.paused ||
-          previous == AppLifecycleState.hidden;
+    // バックグラウンド状態 (paused / hidden) を通過したかどうかを追跡するフラグ
+    final hasSeenBackground = useRef(false);
 
-      if (cameFromBackground && next == AppLifecycleState.resumed) {
-        ref.read(appLockServiceProvider.notifier).lockApp();
+    // アプリのライフサイクル監視
+    ref.listen(appLifecycleProvider, (previous, next) {
+      if (next == AppLifecycleState.paused ||
+          next == AppLifecycleState.hidden) {
+        hasSeenBackground.value = true;
+      } else if (next == AppLifecycleState.resumed) {
+        if (hasSeenBackground.value) {
+          hasSeenBackground.value = false;
+          ref.read(appLockServiceProvider.notifier).lockApp();
+        }
       }
     });
 

--- a/lib/src/features/app_lock/presentation/app_lock_wrapper.dart
+++ b/lib/src/features/app_lock/presentation/app_lock_wrapper.dart
@@ -23,7 +23,11 @@ class AppLockWrapper extends ConsumerWidget {
 
     // アプリのライフサイクル（バックグラウンド復帰）監視
     ref.listen(appLifecycleProvider, (previous, next) {
-      if (next == AppLifecycleState.resumed) {
+      final cameFromBackground =
+          previous == AppLifecycleState.paused ||
+          previous == AppLifecycleState.hidden;
+
+      if (cameFromBackground && next == AppLifecycleState.resumed) {
         ref.read(appLockServiceProvider.notifier).lockApp();
       }
     });

--- a/test/src/features/app_lock/presentation/app_lock_wrapper_test.dart
+++ b/test/src/features/app_lock/presentation/app_lock_wrapper_test.dart
@@ -152,7 +152,7 @@ void main() {
     });
 
     testWidgets(
-      '一時非活性 (inactive) から復帰 (resumed) した場合は lockApp が呼び出されないこと',
+      '一時非活性 (inactive) のみから復帰 (resumed) した場合は lockApp が呼び出されないこと',
       (tester) async {
         final mockService = _TestAppLockService(
           const AppLockState.unlocked(isBiometricEnabled: true),
@@ -170,7 +170,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // キーボード閉じや通信等に伴う inactive -> resumed 遷移
+        // キーボード閉じや通信等に伴う resumed -> inactive -> resumed 遷移
         mockLifecycle.updateLifecycleState(AppLifecycleState.inactive);
         await tester.pump();
 
@@ -182,7 +182,7 @@ void main() {
     );
 
     testWidgets(
-      'バックグラウンド (paused) から復帰 (resumed) した場合は lockApp が呼び出されること',
+      'バックグラウンド (paused -> inactive -> resumed) の復帰シーケンスで lockApp が呼び出されること',
       (tester) async {
         final mockService = _TestAppLockService(
           const AppLockState.unlocked(isBiometricEnabled: true),
@@ -200,8 +200,11 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // 真のバックグラウンドpaused -> resumed 遷移
+        // 真のバックグラウンド paused -> inactive -> resumed 遷移
         mockLifecycle.updateLifecycleState(AppLifecycleState.paused);
+        await tester.pump();
+
+        mockLifecycle.updateLifecycleState(AppLifecycleState.inactive);
         await tester.pump();
 
         mockLifecycle.updateLifecycleState(AppLifecycleState.resumed);
@@ -212,7 +215,7 @@ void main() {
     );
 
     testWidgets(
-      '画面非表示 (hidden) から復帰 (resumed) した場合は lockApp が呼び出されること',
+      '画面非表示 (hidden -> inactive -> resumed) の復帰シーケンスで lockApp が呼び出されること',
       (tester) async {
         final mockService = _TestAppLockService(
           const AppLockState.unlocked(isBiometricEnabled: true),
@@ -230,8 +233,11 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // 画面非表示 hidden -> resumed 遷移
+        // 画面非表示 hidden -> inactive -> resumed 遷移
         mockLifecycle.updateLifecycleState(AppLifecycleState.hidden);
+        await tester.pump();
+
+        mockLifecycle.updateLifecycleState(AppLifecycleState.inactive);
         await tester.pump();
 
         mockLifecycle.updateLifecycleState(AppLifecycleState.resumed);

--- a/test/src/features/app_lock/presentation/app_lock_wrapper_test.dart
+++ b/test/src/features/app_lock/presentation/app_lock_wrapper_test.dart
@@ -247,6 +247,43 @@ void main() {
       },
     );
 
+    testWidgets(
+      '複合バックグラウンド (paused -> hidden -> inactive -> resumed) '
+      'の復帰シーケンスで lockApp が呼び出されること',
+      (tester) async {
+        final mockService = _TestAppLockService(
+          const AppLockState.unlocked(isBiometricEnabled: true),
+        );
+        final mockLifecycle = _TestAppLifecycle();
+
+        await tester.pumpWidget(
+          createTestWidget(
+            const AppLockWrapper(
+              child: Text('Main Screen Content'),
+            ),
+            serviceBuilder: () => mockService,
+            lifecycleBuilder: () => mockLifecycle,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // 複合遷移 paused -> hidden -> inactive -> resumed
+        mockLifecycle.updateLifecycleState(AppLifecycleState.paused);
+        await tester.pump();
+
+        mockLifecycle.updateLifecycleState(AppLifecycleState.hidden);
+        await tester.pump();
+
+        mockLifecycle.updateLifecycleState(AppLifecycleState.inactive);
+        await tester.pump();
+
+        mockLifecycle.updateLifecycleState(AppLifecycleState.resumed);
+        await tester.pump();
+
+        expect(mockService.lockAppCalledCount, equals(1));
+      },
+    );
+
     testWidgets('loading 状態の時は保護シールド(ColoredBox)が描画される', (tester) async {
       await tester.pumpWidget(
         createTestWidget(

--- a/test/src/features/app_lock/presentation/app_lock_wrapper_test.dart
+++ b/test/src/features/app_lock/presentation/app_lock_wrapper_test.dart
@@ -151,32 +151,95 @@ void main() {
       expect(find.byType(PasscodeLockScreen), findsOneWidget);
     });
 
-    testWidgets('アプリ復帰(resumed)時に lockApp が呼び出されること', (tester) async {
-      final mockService = _TestAppLockService(
-        const AppLockState.unlocked(isBiometricEnabled: true),
-      );
-      final mockLifecycle = _TestAppLifecycle();
+    testWidgets(
+      '一時非活性 (inactive) から復帰 (resumed) した場合は lockApp が呼び出されないこと',
+      (tester) async {
+        final mockService = _TestAppLockService(
+          const AppLockState.unlocked(isBiometricEnabled: true),
+        );
+        final mockLifecycle = _TestAppLifecycle();
 
-      await tester.pumpWidget(
-        createTestWidget(
-          const AppLockWrapper(
-            child: Text('Main Screen Content'),
+        await tester.pumpWidget(
+          createTestWidget(
+            const AppLockWrapper(
+              child: Text('Main Screen Content'),
+            ),
+            serviceBuilder: () => mockService,
+            lifecycleBuilder: () => mockLifecycle,
           ),
-          serviceBuilder: () => mockService,
-          lifecycleBuilder: () => mockLifecycle,
-        ),
-      );
-      await tester.pumpAndSettle();
+        );
+        await tester.pumpAndSettle();
 
-      // 一度 inactive にしたのち resumed を通知
-      mockLifecycle.updateLifecycleState(AppLifecycleState.inactive);
-      await tester.pump();
+        // キーボード閉じや通信等に伴う inactive -> resumed 遷移
+        mockLifecycle.updateLifecycleState(AppLifecycleState.inactive);
+        await tester.pump();
 
-      mockLifecycle.updateLifecycleState(AppLifecycleState.resumed);
-      await tester.pump();
+        mockLifecycle.updateLifecycleState(AppLifecycleState.resumed);
+        await tester.pump();
 
-      expect(mockService.lockAppCalledCount, equals(1));
-    });
+        expect(mockService.lockAppCalledCount, equals(0));
+      },
+    );
+
+    testWidgets(
+      'バックグラウンド (paused) から復帰 (resumed) した場合は lockApp が呼び出されること',
+      (tester) async {
+        final mockService = _TestAppLockService(
+          const AppLockState.unlocked(isBiometricEnabled: true),
+        );
+        final mockLifecycle = _TestAppLifecycle();
+
+        await tester.pumpWidget(
+          createTestWidget(
+            const AppLockWrapper(
+              child: Text('Main Screen Content'),
+            ),
+            serviceBuilder: () => mockService,
+            lifecycleBuilder: () => mockLifecycle,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // 真のバックグラウンドpaused -> resumed 遷移
+        mockLifecycle.updateLifecycleState(AppLifecycleState.paused);
+        await tester.pump();
+
+        mockLifecycle.updateLifecycleState(AppLifecycleState.resumed);
+        await tester.pump();
+
+        expect(mockService.lockAppCalledCount, equals(1));
+      },
+    );
+
+    testWidgets(
+      '画面非表示 (hidden) から復帰 (resumed) した場合は lockApp が呼び出されること',
+      (tester) async {
+        final mockService = _TestAppLockService(
+          const AppLockState.unlocked(isBiometricEnabled: true),
+        );
+        final mockLifecycle = _TestAppLifecycle();
+
+        await tester.pumpWidget(
+          createTestWidget(
+            const AppLockWrapper(
+              child: Text('Main Screen Content'),
+            ),
+            serviceBuilder: () => mockService,
+            lifecycleBuilder: () => mockLifecycle,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // 画面非表示 hidden -> resumed 遷移
+        mockLifecycle.updateLifecycleState(AppLifecycleState.hidden);
+        await tester.pump();
+
+        mockLifecycle.updateLifecycleState(AppLifecycleState.resumed);
+        await tester.pump();
+
+        expect(mockService.lockAppCalledCount, equals(1));
+      },
+    );
 
     testWidgets('loading 状態の時は保護シールド(ColoredBox)が描画される', (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## 📝 概要

- AppLockService で .select を使用し認証状態の bool 値のみを監視するよう修正（トークン更新時の build 再実行による誤ロックを遮断）
- AppLockWrapper のライフサイクル監視判定を cameFromBackground (previous == paused || previous == hidden) に厳格化
- docs/app_lock.md の状態遷移図・動作仕様を最新化
- app_lock_wrapper_test.dart に paused/hidden -> resumed での再ロック、および inactive -> resumed でロックされないテストを追加

## ✅ 確認事項

- [x] AIによるコードレビューを実施し、指摘事項への対応が完了しているか
  - AIレビューは、プルリクエストの作成時（※下書き/ドラフト状態を除く）および、公開後のプルリクエストに新しいコミットが追加（プッシュ）されたタイミングで自動実行されます。
  - **下書き（ドラフト）状態では自動実行されません。** 下書きの状態でレビューを動かしたい場合や、手動で再実行したい場合は、プルリクエストのコメント欄で `@coderabbitai review` と入力してください。
  - コメント欄で以下のコマンドを使用し、CodeRabbitの動きをコントロールできます：
    - `@coderabbitai review` : 新しく追加された変更箇所（差分）だけをレビューします。
    - `@coderabbitai full review` : プルリクエスト全体のプログラムを最初からレビューし直します。
    - `@coderabbitai pause` : 自動レビューを一時停止します。
    - `@coderabbitai resume` : 自動レビューを再開します。

- [x] テストのカバレッジが100%になっているか（テストはGitHub Actionsで自動実行され、カバレッジはコメントでレポートされる）
  - ※100%になっていない場合は、以下にその理由を記載すること
    - (100%では無い理由)

## ❕ 関連するIssue

Closes #204 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * アプリ復帰時の不要なロックを防止し、バックグラウンド化または非表示状態を経由した復帰時のみロックするよう改善しました。
  * 一時的な非アクティブ状態や生体認証中の誤ったロックを防ぎ、認証処理の安定性を向上しました。
  * Firebase設定や認証状態に変更があった場合のみ処理を更新し、動作効率を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->